### PR TITLE
return nothing for type stability

### DIFF
--- a/src/forces.jl
+++ b/src/forces.jl
@@ -93,7 +93,7 @@ function force! end
     fdr = f * dr
     forces[i] -= fdr
     forces[j] += fdr
-    return forces
+    return nothing
 end
 
 @fastmath @inbounds function force!(forces,
@@ -116,7 +116,7 @@ end
     fdr = f * dr
     forces[i] -= fdr
     forces[j] += fdr
-    return forces
+    return nothing
 end
 
 @fastmath @inbounds function force!(forces,
@@ -133,7 +133,7 @@ end
     fdr = f * dr
     forces[i] -= fdr
     forces[j] += fdr
-    return forces
+    return nothing
 end
 
 function force!(forces,
@@ -147,7 +147,7 @@ function force!(forces,
     fdr = f * normalize(dr)
     forces[i] -= fdr
     forces[j] += fdr
-    return forces
+    return nothing
 end
 
 function force!(forces,
@@ -158,7 +158,7 @@ function force!(forces,
     f = c * normalize(ab)
     forces[b.i] += f
     forces[b.j] -= f
-    return forces
+    return nothing
 end
 
 # Sometimes domain error occurs for acos if the value is > 1.0 or < -1.0
@@ -178,7 +178,7 @@ function force!(forces,
     forces[a.i] += fa
     forces[a.j] += fb
     forces[a.k] += fc
-    return forces
+    return nothing
 end
 
 function force!(forces,
@@ -202,5 +202,5 @@ function force!(forces,
     forces[d.j] += fb
     forces[d.k] += fc
     forces[d.l] += f_d
-    return forces
+    return nothing
 end


### PR DESCRIPTION
I also added `return nothing` for the functions without branches for consistency.