### PR TITLE
Ignore Manifest.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build
 nbs/*
 todo.txt
+/Manifest.toml


### PR DESCRIPTION
Since the Manifest is not checked in, it would be easier to add it to .gitignore to avoid accidentally adding it.