### PR TITLE
Update adjust_bounds by removing iteration

### DIFF
--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -40,13 +40,7 @@ end
 Ensure a coordinate is within the simulation box and return the coordinate.
 """
 function adjust_bounds(c::Real, box_size::Real)
-    while c >= box_size
-        c -= box_size
-    end
-    while c < zero(c)
-        c += box_size
-    end
-    return c
+    return c - floor(c / box_size) * box_size
 end
 
 adjust_bounds_vec(v, bs) = adjust_bounds.(v, bs)


### PR DESCRIPTION
The `adjust_bounds` is optimized into a one-line using the `floor` in base julia.
Here is the simple benchmark.

benchamarked julia version : 1.6.1

```julia
julia> @time adjust_bounds(90001.0,3.0)
  0.000029 seconds
1.0

julia> @time adjust_bounds_new(90001.0,3.0) # this is the function proposed
  0.000000 seconds
1.0
```