### PR TITLE
Implement cubic spline cutoff

### DIFF
--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -585,6 +585,7 @@ The available cutoffs are:
 - [`DistanceCutoff`](@ref)
 - [`ShiftedPotentialCutoff`](@ref)
 - [`ShiftedForceCutoff`](@ref)
+-[`CubicSplineCutoff`](@ref)
 
 ## Simulators
 

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -585,7 +585,7 @@ The available cutoffs are:
 - [`DistanceCutoff`](@ref)
 - [`ShiftedPotentialCutoff`](@ref)
 - [`ShiftedForceCutoff`](@ref)
--[`CubicSplineCutoff`](@ref)
+- [`CubicSplineCutoff`](@ref)
 
 ## Simulators
 

--- a/src/cutoffs.jl
+++ b/src/cutoffs.jl
@@ -132,7 +132,7 @@ cutoff_points(::Type{CubicSplineCutoff{D,S,I}}) where {D,S,I} = 2
     Va = potential(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params)
     dVa = -force_divr_nocutoff(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params) * cutoff.dist_activation
     
-    return -((6t^2 - 6t) * Va / (cutoff.dist_cutoff-ra) + (3t^2 - 4t + 1) * dVa)/r
+    return -((6t^2 - 6t) * Va / (cutoff.dist_cutoff-cutoff.dist_activation) + (3t^2 - 4t + 1) * dVa)/r
 
 end
 

--- a/src/cutoffs.jl
+++ b/src/cutoffs.jl
@@ -143,5 +143,5 @@ end
     Va = potential(inter, cutoff.sqdist_activation, cutoff.inv_sqdist_activation, params)
     dVa = -force_divr_nocutoff(inter, cutoff.sqdist_activation, cutoff.inv_sqdist_activation, params) * cutoff.dist_activation
     
-    return (2t^3 - 3t^2 + 1) * Vs + (t^3 - 2t^2 + t) * (cutoff.dist_cutoff-cutoff.dist_activation) * dVa
+    return (2t^3 - 3t^2 + 1) * Va + (t^3 - 2t^2 + t) * (cutoff.dist_cutoff-cutoff.dist_activation) * dVa
 end

--- a/src/cutoffs.jl
+++ b/src/cutoffs.jl
@@ -127,7 +127,7 @@ cutoff_points(::Type{CubicSplineCutoff{D,S,I}}) where {D,S,I} = 2
 
 @fastmath function force_divr_cutoff(cutoff::CubicSplineCutoff, r2, inter, params)
     r = √r2
-    t = (r - ra) / (cutoff.dist_cutoff-cutoff.dist_activation)
+    t = (r - cutoff.dist_activation) / (cutoff.dist_cutoff-cutoff.dist_activation)
 
     Va = potential(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params)
     dVa = -force_divr_nocutoff(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params) * cutoff.dist_activation

--- a/src/cutoffs.jl
+++ b/src/cutoffs.jl
@@ -129,8 +129,8 @@ cutoff_points(::Type{CubicSplineCutoff{D,S,I}}) where {D,S,I} = 2
     r = √r2
     t = (r - cutoff.dist_activation) / (cutoff.dist_cutoff-cutoff.dist_activation)
 
-    Va = potential(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params)
-    dVa = -force_divr_nocutoff(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params) * cutoff.dist_activation
+    Va = potential(inter, cutoff.sqdist_activation, cutoff.inv_sqdist_activation, params)
+    dVa = -force_divr_nocutoff(inter, cutoff.sqdist_activation, cutoff.inv_sqdist_activation, params) * cutoff.dist_activation
     
     return -((6t^2 - 6t) * Va / (cutoff.dist_cutoff-cutoff.dist_activation) + (3t^2 - 4t + 1) * dVa)/r
 
@@ -140,8 +140,8 @@ end
     r = √r2
     t = (r - cutoff.dist_activation) / (cutoff.dist_cutoff-cutoff.dist_activation)
 
-    Va = potential(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params)
-    dVa = -force_divr_nocutoff(inter, cutoff.activation_dist, cutoff.inv_activation_dist, params) * cutoff.dist_activation
+    Va = potential(inter, cutoff.sqdist_activation, cutoff.inv_sqdist_activation, params)
+    dVa = -force_divr_nocutoff(inter, cutoff.sqdist_activation, cutoff.inv_sqdist_activation, params) * cutoff.dist_activation
     
     return (2t^3 - 3t^2 + 1) * Vs + (t^3 - 2t^2 + t) * (cutoff.dist_cutoff-cutoff.dist_activation) * dVa
 end

--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -52,7 +52,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip.(zero(coord_i)) * inter.force_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             f = force_divr_nocutoff(inter, r2, inv(r2), params)
         else
             f = force_divr_cutoff(cutoff, r2, inter, params)
@@ -94,7 +94,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip(zero(box_size[1])) * inter.energy_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             pe = potential(inter, r2, inv(r2), params)
         else
             pe = potential_cutoff(cutoff, r2, inter, params)

--- a/src/interactions/lennard_jones.jl
+++ b/src/interactions/lennard_jones.jl
@@ -79,7 +79,7 @@ is_solute(at) = false
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip.(zero(coord_i)) * inter.force_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             f = force_divr_nocutoff(inter, r2, inv(r2), params)
         else
             f = force_divr_cutoff(cutoff, r2, inter, params)
@@ -133,7 +133,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip(zero(box_size[1])) * inter.energy_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             pe = potential(inter, r2, inv(r2), params)
         else
             pe = potential_cutoff(cutoff, r2, inter, params)

--- a/src/interactions/mie.jl
+++ b/src/interactions/mie.jl
@@ -67,7 +67,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip.(zero(coord_i)) * inter.force_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             f = force_divr_nocutoff(inter, r2, inv(r2), params)
         else
             f = force_divr_cutoff(cutoff, r2, inter, params)
@@ -114,7 +114,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip(zero(box_size[1])) * inter.energy_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             potential(inter, r2, inv(r2), params)
         else
             potential_cutoff(cutoff, r2, inter, params)

--- a/src/interactions/soft_sphere.jl
+++ b/src/interactions/soft_sphere.jl
@@ -55,7 +55,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip.(zero(coord_i)) * inter.force_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             f = force_divr_nocutoff(inter, r2, inv(r2), params)
         else
             f = force_divr_cutoff(cutoff, r2, inter, params)
@@ -100,7 +100,7 @@ end
     elseif cutoff_points(C) == 2
         r2 > cutoff.sqdist_cutoff && return ustrip(zero(box_size[1])) * inter.energy_units
 
-        if r2 < cutoff.activation_dist
+        if r2 < cutoff.sqdist_activation
             potential(inter, r2, inv(r2), params)
         else
             potential_cutoff(cutoff, r2, inter, params)

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -154,6 +154,7 @@ end
         LennardJones(cutoff=DistanceCutoff(1.0u"nm"), nl_only=true),
         LennardJones(cutoff=ShiftedPotentialCutoff(1.0u"nm"), nl_only=true),
         LennardJones(cutoff=ShiftedForceCutoff(1.0u"nm"), nl_only=true),
+        LennardJones(cutoff=CubicSplineCutoff(0.6u"nm",1.0u"nm"),nl_only=true),
         SoftSphere(nl_only=true), SoftSphere(nl_only=false),
         Mie(m=5, n=10, nl_only=true), Mie(m=5, n=10, nl_only=false),
         Coulomb(nl_only=true), Coulomb(nl_only=false),


### PR DESCRIPTION
## Cubic Spline implementation

This is a suggestion to add a spline cutoff, which interpolates between the true potential at a set activation distance and zero at a cutoff distance. The interpolation itself is based on a [cubic Hermite spline](https://en.wikipedia.org/wiki/Cubic_Hermite_spline).

# Main addition
The main addition consists in a new cutoff type, `CubicSplineCutoff` :
```
struct CubicSplineCutoff{D,S,I}
    dist_cutoff::D
    sqdist_cutoff::S
    inv_sqdist_cutoff::I

    dist_activation::D
    sqdist_activation::S
    inv_sqdist_activation::I
end
```
This cutoff comes with two methods 

`force_divr_cutoff(cutoff::CubicSplineCutoff, r2, inter, params)`
`potential_cutoff(cutoff::CubicSplineCutoff, r2, inter, params)`

which define the behaviour of the cutoff within the cutoff region, between `dist_activation` and `dist_cutoff` 

# Small adjustments
The naming convention used above required changing some of the code in the "interactions" folder, specifically the `potential_energy` and `force` methods defined in coulomb.jl, lennard_jones.jl, mie.jl and soft_sphere.jl. This is because originally, these methods enforce the cutoff in the case of two cutoff points (as is the case here) if the squared distance between two atoms is between cutoff.activation_dist and cutoff.sqdist_cutoff, which is misleading.
