### PR TITLE
modify Dict loggers to NamedTuple throughout

### DIFF
--- a/docs/src/differentiable.md
+++ b/docs/src/differentiable.md
@@ -73,7 +73,7 @@ simulator = VelocityVerlet(
 
 function loss(σ)
     atoms = [Atom(0, 0.0, atom_mass, σ, 0.2, false) for i in 1:n_atoms]
-    loggers = Dict("coords" => CoordinateLogger(Float64, 10))
+    loggers = (coords = CoordinateLogger(Float64, 10))
 
     s = System(
         atoms=atoms,
@@ -184,7 +184,7 @@ simulator = VelocityVerlet(
 
 function loss(θ)
     atoms = [Atom(0, 0.0, atom_mass, 0.0, 0.0, false) for i in 1:n_atoms]
-    loggers = Dict("coords" => CoordinateLogger(Float64, 2))
+    loggers = (coords = CoordinateLogger(Float64, 2))
     specific_inter_lists = (
         InteractionList2Atoms(
             [1, 2, 4, 5],
@@ -326,7 +326,7 @@ simulator = VelocityVerlet(
 
 function loss()
     atoms = [Atom(0, 0.0f0, mass, 0.0f0, 0.0f0, false) for i in 1:n_atoms]
-    loggers = Dict("coords" => CoordinateLogger(Float32, 10))
+    loggers = (coords = CoordinateLogger(Float32, 10))
     specific_inter_lists = (
         InteractionList2Atoms([1], [3], [""], [NNBond()]),
     )
@@ -352,7 +352,7 @@ function loss()
 
     Zygote.ignore() do
         printfmt("Dist end {:6.3f}  |  Loss {:6.3f}\n", dist_end, loss_val)
-        visualize(s.loggers["coords"], box_size, "sim.mp4")
+        visualize(s.loggers.coords, box_size, "sim.mp4")
     end
 
     return loss_val

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -49,9 +49,9 @@ sys = System(
     coords=coords,
     velocities=velocities,
     box_size=box_size,
-    loggers=Dict(
-        "temp"   => TemperatureLogger(10),
-        "coords" => CoordinateLogger(10),
+    loggers=(
+        temp = TemperatureLogger(10),
+        coords = CoordinateLogger(10),
     ),
 )
 
@@ -67,7 +67,7 @@ By default the simulation is run in parallel on the [number of threads](https://
 An animation of the stored coordinates can be saved by using [`visualize`](@ref), which is available when [GLMakie.jl](https://github.com/JuliaPlots/Makie.jl) is imported.
 ```julia
 using GLMakie
-visualize(sys.loggers["coords"], box_size, "sim_lj.mp4")
+visualize(sys.loggers.coords, box_size, "sim_lj.mp4")
 ```
 ![LJ simulation](images/sim_lj.gif)
 
@@ -97,9 +97,9 @@ sys = System(
     coords=coords,
     velocities=velocities,
     box_size=box_size,
-    loggers=Dict(
-        "temp"   => TemperatureLogger(typeof(1.0f0u"K"), 10),
-        "coords" => CoordinateLogger(typeof(1.0f0u"nm"), 10),
+    loggers=(
+        temp = TemperatureLogger(typeof(1.0f0u"K"), 10),
+        coords = CoordinateLogger(typeof(1.0f0u"nm"), 10),
     ),
 )
 
@@ -156,9 +156,9 @@ sys = System(
     velocities=velocities,
     box_size=box_size,
     neighbor_finder=neighbor_finder,
-    loggers=Dict(
-        "temp" => TemperatureLogger(10),
-        "coords" => CoordinateLogger(10),
+    loggers=(
+        temp = TemperatureLogger(10),
+        coords = CoordinateLogger(10),
     ),
 )
 
@@ -171,7 +171,7 @@ simulate!(sys, simulator, 1_000)
 This time when we view the trajectory we can add lines to show the bonds.
 ```julia
 visualize(
-    sys.loggers["coords"],
+    sys.loggers.coords,
     box_size,
     "sim_diatomic.mp4";
     connections=[(i, i + (n_atoms ÷ 2)) for i in 1:(n_atoms ÷ 2)],
@@ -198,7 +198,7 @@ sys = System(
     coords=coords,
     velocities=velocities,
     box_size=box_size,
-    loggers=Dict("coords" => CoordinateLogger(Float32, 10; dims=2)),
+    loggers=(coords = CoordinateLogger(Float32, 10; dims=2),),
     force_units=NoUnits,
     energy_units=NoUnits,
 )
@@ -208,7 +208,7 @@ simulate!(sys, simulator, 2_000)
 When we view the simulation we can use some extra options:
 ```julia
 visualize(
-    sys.loggers["coords"],
+    sys.loggers.coords,
     box_size,
     "sim_gravity.mp4";
     trails=4,
@@ -235,9 +235,9 @@ ff = OpenMMForceField(
 sys = System(
     joinpath(data_dir, "6mrr_equil.pdb"),
     ff;
-    loggers=Dict(
-        "energy" => TotalEnergyLogger(10),
-        "writer" => StructureWriter(10, "traj_6mrr_1ps.pdb", ["HOH"]),
+    loggers=(
+        energy = TotalEnergyLogger(10),
+        writer = StructureWriter(10, "traj_6mrr_1ps.pdb", ["HOH"]),
     ),
 )
 
@@ -262,9 +262,9 @@ Molly also has a rudimentary parser of [Gromacs](http://www.gromacs.org) topolog
 sys = System(
     joinpath(dirname(pathof(Molly)), "..", "data", "5XER", "gmx_coords.gro"),
     joinpath(dirname(pathof(Molly)), "..", "data", "5XER", "gmx_top_ff.top");
-    loggers=Dict(
-        "temp"   => TemperatureLogger(10),
-        "writer" => StructureWriter(10, "traj_5XER_1ps.pdb"),
+    loggers=(
+        temp = TemperatureLogger(10),
+        writer = StructureWriter(10, "traj_5XER_1ps.pdb"),
     ),
 )
 
@@ -383,9 +383,9 @@ sys = System(
     velocities=velocities,
     box_size=box_size,
     neighbor_finder=neighbor_finder,
-    loggers=Dict(
-        "coords" => CoordinateLogger(Float64, 10; dims=2),
-        "SIR"    => SIRLogger(10, []),
+    loggers=(
+        coords = CoordinateLogger(Float64, 10; dims=2),
+        SIR = SIRLogger(10, []),
     ),
     force_units=NoUnits,
     energy_units=NoUnits,
@@ -393,7 +393,7 @@ sys = System(
 
 simulate!(sys, simulator, n_steps)
 
-visualize(sys.loggers["coords"], box_size, "sim_agent.mp4"; markersize=0.1)
+visualize(sys.loggers.coords, box_size, "sim_agent.mp4"; markersize=0.1)
 ```
 ![Agent simulation](images/sim_agent.gif)
 
@@ -402,9 +402,9 @@ We can use the logger to plot the fraction of people susceptible (blue), infecte
 ```julia
 using Plots
 
-sir_matrix = zeros(length(sys.loggers["SIR"].fracs_sir), 3)
+sir_matrix = zeros(length(sys.loggers.SIR.fracs_sir), 3)
 for i = 1:101
-    sir_matrix[i, :] .= sys.loggers["SIR"].fracs_sir[i][:]
+    sir_matrix[i, :] .= sys.loggers.SIR.fracs_sir[i][:]
 end
 
 plot(sir_matrix)
@@ -804,9 +804,9 @@ function Molly.log_property!(logger::MyLogger, sys, neighbors, step_n; parallel=
 end
 ```
 The use of `n_steps` is optional and is an example of how to record a property every n steps through the simulation.
-To use your custom logger, add it to the dictionary of loggers given when creating the [`System`](@ref):
+To use your custom logger, add it to the named tuple of loggers given when creating the [`System`](@ref):
 ```julia
-loggers = Dict("mylogger" => MyLogger(10))
+loggers = (mylogger = MyLogger(10),)
 ```
 In addition to being run at the end of each step, loggers are run before the first step, i.e. at step 0.
 This means that a logger that records a value every step for a simulation with 100 steps will end up with 101 values.
@@ -848,7 +848,6 @@ sys = System(atoms=atoms,
     pairwise_inters=pairwise_inters,
     specific_inter_lists=specific_inter_lists,
     box_size=box_size,
-    loggers=Dict{Symbol,Any}()
     )
 ```
 
@@ -862,11 +861,20 @@ simulate!(sys, simulator, 10000)
 ```console
 temperature(sys) = 48.76795299825687 K
 ```
-Good. Next we define our correlation logger, add it to the system's loggers and run a long simulation
+Good. Next we define our correlation logger, add it to the system's loggers and run a long simulation. Note we need to redeclare the system when adding a logger.
 ```julia
 V(s::System, neighbors=nothing) = s.velocities
 V_Type = eltype(sys.velocities)
-sys.loggers = Dict(:velocity_autocorrelation => TimeCorrelationLogger(V_Type, V_Type, V, V, n_atoms, 1000))
+
+sys = System(atoms=atoms,
+    coords=sys.coords,
+    velocities=sys.velocities,
+    neighbor_finder=nf,
+    pairwise_inters=pairwise_inters,
+    specific_inter_lists=specific_inter_lists,
+    box_size= box_size,
+    loggers=(velocity_autocorrelation= TimeCorrelationLogger(V_Type, V_Type, V, V, n_atoms, 1000),)
+    )
 simulate!(sys, simulator, 100000)
 ```
 
@@ -875,7 +883,7 @@ Check the output:
 using Plots, UnitfulRecipes
 
 t_range=(0:999)*u"ps"
-plot(t_range,sys.loggers[:velocity_autocorrelation].normalized_correlations,xlabel="time",ylabel="correlation",label="C(t)")
+plot(t_range,sys.loggers.velocity_autocorrelation.normalized_correlations,xlabel="time",ylabel="correlation",label="C(t)")
 ```
 ![Velocity Autocorrelations](images/velocity_autocorrelations.png)\
 As expected, the velocities are highly correlated at small time offsets and the correlation decays rapidly. The oscillatory behavior is due to the contribution of the harmonic bond interactions.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -24,7 +24,7 @@ ff = OpenMMForceField(
 sys = System(
     joinpath(data_dir, "6mrr_equil.pdb"),
     ff;
-    loggers=Dict("temp" => TemperatureLogger(100)),
+    loggers=(temp = TemperatureLogger(100)),
 )
 
 minimizer = SteepestDescentMinimizer()
@@ -60,8 +60,8 @@ for (i, temp) in enumerate(temps)
 end
 scatter!(
     ax,
-    100 .* (1:length(sys.loggers["temp"].temperatures)),
-    ustrip.(sys.loggers["temp"].temperatures),
+    100 .* (1:length(sys.loggers.temp.temperatures)),
+    ustrip.(sys.loggers.temp.temperatures),
     markersize=5,
 )
 save("annealing.png", f)
@@ -111,7 +111,7 @@ sys = System(
     coords=coords .+ (SVector(5e8, 5e8, 5e8)u"km",),
     velocities=velocities,
     box_size=box_size,
-    loggers=Dict("coords" => CoordinateLogger(typeof(1.0u"km"), 10)),
+    loggers=(coords = CoordinateLogger(typeof(1.0u"km"), 10)),
     force_units=u"kg * km * d^-2",
     energy_units=u"kg * km^2 * d^-2",
 )
@@ -124,7 +124,7 @@ simulator = Verlet(
 simulate!(sys, simulator, 3650) # 1 year
 
 visualize(
-    sys.loggers["coords"],
+    sys.loggers.coords,
     box_size,
     "sim_planets.mp4";
     trails=5,
@@ -239,9 +239,9 @@ sys = System(
     velocities=velocities,
     box_size=box_size,
     neighbor_finder=neighbor_finder,
-    loggers=Dict(
-        "coords" => CoordinateLogger(Float64, 20; dims=2),
-        "bonds"  => BondLogger(20, []),
+    loggers=(
+        coords = CoordinateLogger(Float64, 20; dims=2),
+        bonds = BondLogger(20, []),
     ),
     force_units=NoUnits,
     energy_units=NoUnits,
@@ -257,11 +257,11 @@ for i in 1:length(sys)
 end
 
 visualize(
-    sys.loggers["coords"],
+    sys.loggers.coords,
     box_size,
     "sim_mutbond.mp4";
     connections=connections,
-    connection_frames=sys.loggers["bonds"].bonds,
+    connection_frames=sys.loggers.bonds.bonds,
     markersize=0.1,
 )
 ```

--- a/test/energy_conservation.jl
+++ b/test/energy_conservation.jl
@@ -27,9 +27,9 @@ using Test
                 coords=place_atoms(n_atoms, box_size, 0.6u"nm"),
                 velocities=[velocity(atom_mass, temp) for i in 1:n_atoms],
                 box_size=box_size,
-                loggers=Dict(
-                    "coords" => CoordinateLogger(100),
-                    "energy" => TotalEnergyLogger(100),
+                loggers=(
+                    coords = CoordinateLogger(100),
+                    energy = TotalEnergyLogger(100),
                 ),
             )
 
@@ -39,13 +39,13 @@ using Test
             ΔE = total_energy(s) - E0
             @test abs(ΔE) < 2e-2u"kJ * mol^-1"
 
-            Es = s.loggers["energy"].energies
+            Es = s.loggers.energy.energies
             maxΔE = maximum(abs.(Es .- E0))
             @test maxΔE < 2e-2u"kJ * mol^-1"
 
             @test abs(Es[end] - Es[1]) < 2e-2u"kJ * mol^-1"
 
-            final_coords = last(s.loggers["coords"].coords)
+            final_coords = last(s.loggers.coords.coords)
             @test all(all(c .> 0.0u"nm") for c in final_coords)
             @test all(all(c .< box_size) for c in final_coords)
         end

--- a/test/protein.jl
+++ b/test/protein.jl
@@ -4,11 +4,11 @@
     s = System(
         joinpath(data_dir, "5XER", "gmx_coords.gro"),
         joinpath(data_dir, "5XER", "gmx_top_ff.top");
-        loggers=Dict(
-            "temp"   => TemperatureLogger(10),
-            "coords" => CoordinateLogger(10),
-            "energy" => TotalEnergyLogger(10),
-            "writer" => StructureWriter(10, temp_fp_pdb),
+        loggers=(
+            temp = TemperatureLogger(10),
+            coords = CoordinateLogger(10),
+            energy = TotalEnergyLogger(10),
+            writer = StructureWriter(10, temp_fp_pdb),
         ),
     )
     simulator = VelocityVerlet(dt=0.0002u"ps", coupling=AndersenThermostat(temp, 10.0u"ps"))
@@ -39,10 +39,10 @@ end
         Float32,
         joinpath(data_dir, "5XER", "gmx_coords.gro"),
         joinpath(data_dir, "5XER", "gmx_top_ff.top");
-        loggers=Dict(
-            "temp"   => TemperatureLogger(typeof(1.0f0u"K"), 10),
-            "coords" => CoordinateLogger(typeof(1.0f0u"nm"), 10),
-            "energy" => TotalEnergyLogger(typeof(1.0f0u"kJ * mol^-1"), 10),
+        loggers=(
+            temp = TemperatureLogger(typeof(1.0f0u"K"), 10),
+            coords = CoordinateLogger(typeof(1.0f0u"nm"), 10),
+            energy = TotalEnergyLogger(typeof(1.0f0u"kJ * mol^-1"), 10),
         ),
     )
     simulator = VelocityVerlet(dt=0.0002f0u"ps", coupling=AndersenThermostat(temp, 10.0f0u"ps"))

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -15,9 +15,9 @@
             n_steps=10,
             dist_cutoff=2.0u"nm",
         ),
-        loggers=Dict(
-            "temp"   => TemperatureLogger(100),
-            "coords" => CoordinateLogger(100; dims=2),
+        loggers=(
+            temp = TemperatureLogger(100),
+            coords = CoordinateLogger(100; dims=2),
         ),
     )
     random_velocities!(s, temp)
@@ -32,15 +32,15 @@
 
     @time simulate!(s, simulator, n_steps; parallel=false)
 
-    @test length(s.loggers["coords"].coords) == 201
-    final_coords = last(s.loggers["coords"].coords)
+    @test length(s.loggers.coords.coords) == 201
+    final_coords = last(s.loggers.coords.coords)
     @test all(all(c .> 0.0u"nm") for c in final_coords)
     @test all(all(c .< box_size) for c in final_coords)
     displacements(final_coords, box_size)
     distances(final_coords, box_size)
     rdf(final_coords, box_size)
 
-    run_visualize_tests && visualize(s.loggers["coords"], box_size, temp_fp_viz)
+    run_visualize_tests && visualize(s.loggers.coords, box_size, temp_fp_viz)
 end
 
 @testset "Lennard-Jones" begin
@@ -65,15 +65,15 @@ end
                 n_steps=10,
                 dist_cutoff=2.0u"nm",
             ),
-            loggers=Dict(
-                "temp"   => TemperatureLogger(100),
-                "coords" => CoordinateLogger(100),
-                "vels"   => VelocityLogger(100),
-                "energy" => TotalEnergyLogger(100),
-                "ke"     => KineticEnergyLogger(100),
-                "pe"     => PotentialEnergyLogger(100),
-                "force"  => ForceLogger(100),
-                "writer" => StructureWriter(100, temp_fp_pdb),
+            loggers=(
+                temp = TemperatureLogger(100),
+                coords = CoordinateLogger(100),
+                vels = VelocityLogger(100),
+                energy = TotalEnergyLogger(100),
+                ke = KineticEnergyLogger(100),
+                pe = PotentialEnergyLogger(100),
+                force = ForceLogger(100),
+                writer = StructureWriter(100, temp_fp_pdb),
             ),
         )
 
@@ -102,28 +102,28 @@ end
 
         @time simulate!(s, simulator, n_steps; parallel=parallel)
 
-        show(devnull, s.loggers["temp"])
-        show(devnull, s.loggers["coords"])
-        show(devnull, s.loggers["vels"])
-        show(devnull, s.loggers["energy"])
-        show(devnull, s.loggers["ke"])
-        show(devnull, s.loggers["pe"])
-        show(devnull, s.loggers["writer"])
+        show(devnull, s.loggers.temp)
+        show(devnull, s.loggers.coords)
+        show(devnull, s.loggers.vels)
+        show(devnull, s.loggers.energy)
+        show(devnull, s.loggers.ke)
+        show(devnull, s.loggers.pe)
+        show(devnull, s.loggers.writer)
 
-        final_coords = last(s.loggers["coords"].coords)
+        final_coords = last(s.loggers.coords.coords)
         @test all(all(c .> 0.0u"nm") for c in final_coords)
         @test all(all(c .< box_size) for c in final_coords)
         displacements(final_coords, box_size)
         distances(final_coords, box_size)
         rdf(final_coords, box_size)
-        @test unit(velocity_autocorr(s.loggers["vels"])) == u"nm^2 * ps^-2"
+        @test unit(velocity_autocorr(s.loggers.vels)) == u"nm^2 * ps^-2"
 
         traj = read(temp_fp_pdb, BioStructures.PDB)
         rm(temp_fp_pdb)
         @test BioStructures.countmodels(traj) == 201
         @test BioStructures.countatoms(first(traj)) == 100
 
-        run_visualize_tests && visualize(s.loggers["coords"], box_size, temp_fp_viz)
+        run_visualize_tests && visualize(s.loggers.coords, box_size, temp_fp_viz)
     end
 end
 
@@ -149,7 +149,7 @@ end
             n_steps=10,
             dist_cutoff=2.0u"nm",
         ),
-        loggers=Dict("coords" => CoordinateLogger(100)),
+        loggers=(coords = CoordinateLogger(100),),
     )
     random_velocities!(s, temp)
 
@@ -192,16 +192,16 @@ end
             n_steps=10,
             dist_cutoff=2.0u"nm",
         ),
-        loggers=Dict(
-            "temp"   => TemperatureLogger(10),
-            "coords" => CoordinateLogger(10),
+        loggers=(
+            temp = TemperatureLogger(10),
+            coords = CoordinateLogger(10),
         ),
     )
 
     @time simulate!(s, simulator, n_steps; parallel=false)
 
     if run_visualize_tests
-        visualize(s.loggers["coords"], box_size, temp_fp_viz;
+        visualize(s.loggers.coords, box_size, temp_fp_viz;
                     connections=[(i, i + (n_atoms ÷ 2)) for i in 1:(n_atoms ÷ 2)],
                     trails=2)
     end
@@ -244,10 +244,10 @@ end
             velocities=[velocity(10.0u"u", temp) .* 0.01 for i in 1:n_atoms],
             box_size=box_size,
             neighbor_finder=neighbor_finder,
-            loggers=Dict(
-                "temp"   => TemperatureLogger(100),
-                "coords" => CoordinateLogger(100),
-                "energy" => TotalEnergyLogger(100),
+            loggers=(
+                temp = TemperatureLogger(100),
+                coords = CoordinateLogger(100),
+                energy = TotalEnergyLogger(100),
             ),
         )
 
@@ -279,11 +279,11 @@ end
             n_steps=10,
             dist_cutoff=2.0u"nm",
         ),
-        loggers=Dict(
-            "temp"   => TemperatureLogger(100),
-            "coords" => CoordinateLogger(100),
-            "energy" => TotalEnergyLogger(100),
-            "autocorrelations" => TimeCorrelationLogger(vtype,vtype,V,V,n_atoms,100)
+        loggers=(
+            temp = TemperatureLogger(100),
+            coords = CoordinateLogger(100),
+            energy = TotalEnergyLogger(100),
+            autocorrelations = TimeCorrelationLogger(vtype,vtype,V,V,n_atoms,100)
         ),
     )
 
@@ -300,11 +300,11 @@ end
             n_steps=10,
             dist_cutoff=2.0,
         ),
-        loggers=Dict(
-            "temp"   => TemperatureLogger(Float64, 100),
-            "coords" => CoordinateLogger(Float64, 100),
-            "energy" => TotalEnergyLogger(Float64, 100),
-            "autocorrelations" => TimeCorrelationLogger(vtype_nounits,vtype_nounits,V,V,n_atoms,100)
+        loggers=(
+            temp = TemperatureLogger(Float64, 100),
+            coords = CoordinateLogger(Float64, 100),
+            energy = TotalEnergyLogger(Float64, 100),
+            autocorrelations = TimeCorrelationLogger(vtype_nounits,vtype_nounits,V,V,n_atoms,100)
         ),
         force_units=NoUnits,
         energy_units=NoUnits,
@@ -318,19 +318,19 @@ end
     simulate!(s, simulator, n_steps; parallel=false)
     simulate!(s_nounits, simulator_nounits, n_steps; parallel=false)
 
-    coords_diff = s.loggers["coords"].coords[end] .- s_nounits.loggers["coords"].coords[end] * u"nm"
+    coords_diff = s.loggers.coords.coords[end] .- s_nounits.loggers.coords.coords[end] * u"nm"
     @test median([maximum(abs.(c)) for c in coords_diff]) < 1e-8u"nm"
 
-    final_energy = s.loggers["energy"].energies[end]
-    final_energy_nounits = s_nounits.loggers["energy"].energies[end] * u"kJ * mol^-1"
+    final_energy = s.loggers.energy.energies[end]
+    final_energy_nounits = s_nounits.loggers.energy.energies[end] * u"kJ * mol^-1"
     @test isapprox(final_energy, final_energy_nounits, atol=5e-4u"kJ * mol^-1")
 
     
-    @test unit(first(s.loggers["autocorrelations"].normalized_correlations))==NoUnits
-    @test unit(first(s.loggers["autocorrelations"].unnormalized_correlations))==u"nm^2 * ps^-2"
+    @test unit(first(s.loggers.autocorrelations.normalized_correlations))==NoUnits
+    @test unit(first(s.loggers.autocorrelations.unnormalized_correlations))==u"nm^2 * ps^-2"
     
-    show(devnull,s_nounits.loggers["autocorrelations"].normalized_correlations)
-    show(devnull,s_nounits.loggers["autocorrelations"].unnormalized_correlations)
+    show(devnull,s_nounits.loggers.autocorrelations.normalized_correlations)
+    show(devnull,s_nounits.loggers.autocorrelations.unnormalized_correlations)
 end
 
 @testset "Langevin Splitting" begin
@@ -351,8 +351,8 @@ end
             n_steps=10,
             dist_cutoff=2.0u"nm",
         ),
-        loggers=Dict(
-            "temp"   => TemperatureLogger(10),
+        loggers=(
+            temp = TemperatureLogger(10),
         ),
     )
     s2=deepcopy(s1)
@@ -361,10 +361,10 @@ end
     simulator2=LangevinSplitting(dt=0.002u"ps",friction=10.0u"u * ps^-1",temperature=temp,splitting="BAOA")
 
     @time simulate!(s1,simulator1,n_steps;rng=MersenneTwister(rseed))
-    @test 280.0u"K"<= mean(s1.loggers["temp"].temperatures[end-100:end])<=320.0u"K"
+    @test 280.0u"K"<= mean(s1.loggers.temp.temperatures[end-100:end])<=320.0u"K"
 
     @time simulate!(s2,simulator2,n_steps;rng=MersenneTwister(rseed))
-    @test 280.0u"K"<= mean(s2.loggers["temp"].temperatures[end-100:end])<=320.0u"K"
+    @test 280.0u"K"<= mean(s2.loggers.temp.temperatures[end-100:end])<=320.0u"K"
 
     atol=1e-5u"nm"
     @test all(all(abs(x1[i]-x2[i])<atol for i=1:3) for (x1,x2)=zip(s1.coords,s2.coords))


### PR DESCRIPTION
# Suggested changes:
Replace every instance of a `System`'s loggers as a `Dict` to a `NamedTuple`.
This is important for type-inference reasons, especially when the `System` has several different loggers. In the case of `TimeCorrelationLogger`, the speedup is significant.

# Cons
This introduces ugly syntax. For example, if
```julia
sys.loggers=(coords=CoordinateLogger(args...))
```
the syntax to access the recorded coordinate history is 
```julia
sys.loggers.coords.coords
```
This could be alleviated by having a common (possibly non-exported) type for all loggers which push some observation onto a history vector, like

```julia
struct GeneralObservableLogger {T,F}
    n_steps::Int64
    history::Vector{T}
    observable::F
end

function log_property!(logger::GeneralObservableLogger,s::System,neighbors=nothing,step_n::Integer=0;parallel::Bool=true)
    if (step_n % logger.n_steps) == 0
        obs=logger.observable(sys,neighbors;parallel=parallel)
        push!(logger.history,obs)
    end
end
```
and have `TemperatureLogger`, `CoordinateLogger`, etc... wrap a constructor for this type.
So logged observations would be accessed through
`sys.loggers.coords.history`
and so on.
This would also shorten `loggers.jl` by removing a lot of boilerplate code / make it easier for users to define custom loggers of this kind. I can implement this change if that sound good.
