### PR TITLE
Block averages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
@@ -56,8 +57,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DelimitedFiles", "FiniteDifferences", "GLMakie", "Statistics", "Test"]
+test = ["Aqua", "DelimitedFiles", "FiniteDifferences", "GLMakie", "Test"]

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -881,7 +881,7 @@ temperature(sys) = 48.76795299825687 K
 ```
 Good. Next we define our correlation logger, add it to the system's loggers and run a long simulation. Note we need to redeclare the system when adding a logger.
 ```julia
-V(s::System, neighbors=nothing) = s.velocities
+V(s::System, args...; kwargs...) = s.velocities # velocity observable (args and kwargs because more complex observables may require neighbors and parallelism)
 V_Type = eltype(sys.velocities)
 
 sys = System(atoms=atoms,

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -782,6 +782,7 @@ The available loggers are:
 - [`StructureWriter`](@ref)
 - [`TimeCorrelationLogger`](@ref)
 - [`AutoCorrelationLogger`](@ref)
+- [`AverageObservableLogger`](@ref)
 
 Many of the loggers can be initialised with just the number of steps between recorded values, e.g. `CoordinateLogger(10)`.
 An optional first argument is the type of the recorded value; the above is equivalent to `CoordinateLogger(typeof(1.0u"nm"), 10)` but if the simulation did not use units then `CoordinateLogger(Float64, 10)` would be required.

--- a/src/Molly.jl
+++ b/src/Molly.jl
@@ -16,6 +16,7 @@ using KernelDensity
 using NearestNeighbors
 using Reexport
 using Requires
+using Statistics
 using Unitful
 using Zygote
 

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -225,7 +225,7 @@ atom_record(at_data, i, coord) = BioStructures.AtomRecord(
     at_data.element == "?" ? "  " : at_data.element, "  "
 )
 
-raw"""
+@doc md"""
 `TimeCorrelationLogger(TA::DataType, TB::DataType, observableA::Function, observableB::Function, observable_length::Integer, n_correlation::Integer)`
 A time correlation logger, which allow to estimate statistical correlations of normalized form
 ```math

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -18,6 +18,7 @@
         loggers=(
             temp = TemperatureLogger(100),
             coords = CoordinateLogger(100; dims=2),
+            avg_temp = AverageObservableLogger(Molly.temperature_wrapper, typeof(temp), 1; n_blocks = 200)
         ),
     )
     random_velocities!(s, temp)
@@ -40,6 +41,9 @@
     distances(final_coords, box_size)
     rdf(final_coords, box_size)
 
+    show(devnull, s.loggers.avg_temp)
+    (t, σ) = values(s.loggers.avg_temp)
+    @test isapprox(t, mean(values(s.loggers.temp)); atol = 3σ)
     run_visualize_tests && visualize(s.loggers.coords, box_size, temp_fp_viz)
 end
 

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -59,9 +59,9 @@ end
     TV=typeof(velocity(10.0u"u", temp))
     TP=typeof(0.2u"kJ * mol^-1")
 
-    V(sys,neighbors=nothing)=sys.velocities
-    pot_obs(sys,neighbors=nothing)=potential_energy(sys,neighbors)
-    kin_obs(sys,neighbors=nothing)=kinetic_energy(sys)
+    V(sys,args...;kwargs...)=sys.velocities
+    pot_obs(sys,neighbors;kwargs...)=potential_energy(sys,neighbors)
+    kin_obs(sys,args...;kwargs...)=kinetic_energy(sys)
 
     for parallel in parallel_list
         s = System(


### PR DESCRIPTION
This PR adds an `AverageObservableLogger` which keeps a running average of some observation, while maintaining an estimation of the standard deviation on this average. 
As an example, the following code 
```julia
using Molly

n_atoms = 1000
atom_mass = 10.0u"u"
atoms = [Atom(mass = atom_mass, σ = 0.2u"nm", ϵ = 0.2u"kJ * mol^-1") for i=1:n_atoms]

# Initialization
box_size = SVector(6.0, 6.0, 6.0)u"nm"
coords = place_diatomics(n_atoms ÷ 2, box_size, 0.2u"nm", 0.2u"nm")

temp = 50.0u"K"
velocities = [velocity(atom_mass, temp)*0.01 for i=1:n_atoms]


# Interaction potentials
pairwise_inters = (SoftSphere(nl_only=true, cutoff=DistanceCutoff(0.6u"nm")),)

bonds = [HarmonicBond(b0=0.2u"nm", kb=10000u"kJ * mol^-1 * nm^-2") for i=1:(n_atoms ÷ 2)]
specific_inter_lists = (InteractionList2Atoms(collect(1:2:n_atoms), collect(2:2:n_atoms), repeat([""], length(bonds)),bonds),)

# Define system
nf = DistanceNeighborFinder(dist_cutoff=0.6u"nm", nb_matrix=trues(n_atoms, n_atoms))


sys = System(atoms=atoms,
    coords=coords,
    velocities=velocities,
    neighbor_finder=nf,
    pairwise_inters=pairwise_inters,
    specific_inter_lists=specific_inter_lists,
    box_size=box_size,
    )
simulator = LangevinSplitting(dt=0.002u"ps", friction=10.0u"u* ps^-1", temperature=temp, splitting="BAOAB")
simulate!(sys,simulator,5000) # equilibriate

sys = System(atoms=atoms,
    coords=coords,
    velocities=velocities,
    neighbor_finder=nf,
    pairwise_inters=pairwise_inters,
    specific_inter_lists=specific_inter_lists,
    box_size=box_size,
    loggers=(avg_temp=AverageObservableLogger(Molly.temperature_wrapper,typeof(1.0u"K"),1),)
    )

simulate!(sys, simulator, 10000)
(t,σ)=values(sys.loggers.avg_temp)
print("t= ",t," ± ",σ)
```
gives as an output
```console
t= 49.79195051999282 K ± 0.07213115483541217 K
```