### PR TITLE
adding overload so GPU kernels execute without unsupported dynamic function call

### DIFF
--- a/src/force.jl
+++ b/src/force.jl
@@ -307,3 +307,6 @@ function forces(s::System{D, true}, neighbors=nothing; parallel::Bool=true) wher
 
     return fs * s.force_units
 end
+
+force(inter, dr, coord_i, coord_j, atom_i, atom_j, boundary, weight_14) =
+    force(inter, dr, coord_i, coord_j, atom_i, atom_j, boundary)

--- a/src/interactions/gravity.jl
+++ b/src/interactions/gravity.jl
@@ -13,12 +13,12 @@ end
 Gravity(; G=Unitful.G, nl_only=false) = Gravity{typeof(G)}(G, nl_only)
 
 @inline @inbounds function force(inter::Gravity,
-                                    dr,
-                                    coord_i,
-                                    coord_j,
-                                    atom_i,
-                                    atom_j,
-                                    boundary)
+                                 dr,
+                                 coord_i,
+                                 coord_j,
+                                 atom_i,
+                                 atom_j,
+                                 boundary)
     r2 = sum(abs2, dr)
 
     mi, mj = atom_i.mass, atom_j.mass


### PR DESCRIPTION
Several GPU kernels are not functional because of an `unsupported dynamic function call to force(...)`. This adds a simple fallback for calling `force(..., weight_14)` as just `force(...)`. It seems to work on my GPU, at least.