### PR TITLE
Add `LennardJonesSoftCore` and `CoulombSoftCore`

### DIFF
--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -527,9 +527,11 @@ In Molly there are three types of interactions:
 
 The available pairwise interactions are:
 - [`LennardJones`](@ref)
+- [`LennardJonesSoftCore`](@ref)
 - [`SoftSphere`](@ref)
 - [`Mie`](@ref)
 - [`Coulomb`](@ref)
+- [`CoulombSoftCore`](@ref)
 - [`CoulombReactionField`](@ref)
 - [`Gravity`](@ref)
 

--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -126,7 +126,7 @@ The potential energy is defined as
 V(r_{ij}) = \frac{q_i q_j}{4 \pi \varepsilon_0 (r_{ij}^6 + \alpha * sigma_{ij}^6 * \lambda^p)^{\frac{1}{6}}}
 ```
 
-Here, ``\\alpha``, ``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For we 
+Here, ``\\alpha``, ``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For 
 `alpha=1` or `lambda=1` we get the standard Coulomb potential.
 """
 struct CoulombSoftCore{C, A, L, P, W, T, F, E} <: PairwiseInteraction

--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -127,7 +127,7 @@ V(r_{ij}) = \frac{q_i q_j}{4 \pi \varepsilon_0 (r_{ij}^6 + \alpha * sigma_{ij}^6
 ```
 
 Here, ``\\alpha``, ``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For 
-`alpha=1` or `lambda=1` we get the standard Coulomb potential.
+`alpha=0` or `lambda=0` we get the standard Coulomb potential.
 """
 struct CoulombSoftCore{C, A, L, P, W, T, F, E} <: PairwiseInteraction
     cutoff::C

--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -115,3 +115,122 @@ end
 @fastmath function potential(::Coulomb, r2, invr2, (coulomb_const, qi, qj))
     (coulomb_const * qi * qj) * √invr2
 end
+
+struct CoulombSoftCore{C, A, L, P, W, T, F, E} <: PairwiseInteraction
+    cutoff::C
+    sc_softness::A
+    sc_lambda::L
+    sc_power::P
+    nl_only::Bool
+    lorentz_mixing::Bool
+    weight_14::W
+    coulomb_const::T
+    force_units::F
+    energy_units::E
+end
+
+function CoulombSoftCore(;
+                    cutoff=NoCutoff(),
+                    sc_softness=1,
+                    sc_lambda=0,
+                    sc_power=2,
+                    nl_only=false,
+                    lorentz_mixing=true,
+                    weight_14=1,
+                    coulomb_const=coulombconst,
+                    force_units=u"kJ * mol^-1 * nm^-1",
+                    energy_units=u"kJ * mol^-1")
+    return Coulomb{typeof(cutoff), typeof(sc_softness), typeof(sc_lambda), typeof(sc_power), typeof(weight_14),
+                   typeof(coulomb_const), typeof(force_units), typeof(energy_units)}(
+        cutoff, nl_only, lorentz_mixing, weight_14, coulomb_const, force_units, energy_units)
+end
+
+@inline @inbounds function force(inter::CoulombSoftCore{C},
+                                    dr,
+                                    coord_i,
+                                    coord_j,
+                                    atom_i,
+                                    atom_j,
+                                    boundary,
+                                    weight_14::Bool=false) where C
+    r2 = sum(abs2, dr)
+
+    cutoff = inter.cutoff
+    coulomb_const = inter.coulomb_const
+    qi, qj = atom_i.charge, atom_j.charge
+    σ = inter.lorentz_mixing ? (atom_i.σ + atom_j.σ) / 2 : sqrt(atom_i.σ * atom_j.σ)
+
+    params = (coulomb_const, qi, qj, σ, inter.sc_softness, inter.sc_lambda, inter.sc_power)
+
+    if cutoff_points(C) == 0
+        f = force_divr_nocutoff(inter, r2, inv(r2), params)
+    elseif cutoff_points(C) == 1
+        r2 > cutoff.sqdist_cutoff && return ustrip.(zero(coord_i)) * inter.force_units
+
+        f = force_divr_cutoff(cutoff, r2, inter, params)
+    elseif cutoff_points(C) == 2
+        r2 > cutoff.sqdist_cutoff && return ustrip.(zero(coord_i)) * inter.force_units
+
+        if r2 < cutoff.sqdist_activation
+            f = force_divr_nocutoff(inter, r2, inv(r2), params)
+        else
+            f = force_divr_cutoff(cutoff, r2, inter, params)
+        end
+    end
+
+    if weight_14
+        return f * dr * inter.weight_14
+    else
+        return f * dr
+    end
+end
+
+@fastmath function force_divr_nocutoff(::CoulombSoftCore, r2, invr2, (coulomb_const, qi, qj, σ, α, λ, p))
+    inv_rsc6 = inv(r2^3 + α * λ^p * σ^6)
+    (coulomb_const * qi * qj) * inv_rsc6^(1/3) * sqrt(r2^5 * inv_rsc6^(5/3)) * √invr2  # √invr2 is for normalizing dr
+end
+
+@inline @inbounds function potential_energy(inter::CoulombSoftCore{C},
+                                            dr,
+                                            coord_i,
+                                            coord_j,
+                                            atom_i,
+                                            atom_j,
+                                            boundary,
+                                            weight_14::Bool=false) where C
+    r2 = sum(abs2, dr)
+
+    cutoff = inter.cutoff
+    coulomb_const = inter.coulomb_const
+    qi, qj = atom_i.charge, atom_j.charge
+    σ = inter.lorentz_mixing ? (atom_i.σ + atom_j.σ) / 2 : sqrt(atom_i.σ * atom_j.σ)
+
+    params = (coulomb_const, qi, qj, σ, inter.sc_softness, inter.sc_lambda, inter.sc_power)
+
+    if cutoff_points(C) == 0
+        pe = potential(inter, r2, inv(r2), params)
+    elseif cutoff_points(C) == 1
+        r2 > cutoff.sqdist_cutoff && return ustrip(zero(coord_i[1])) * inter.energy_units
+
+        pe = potential_cutoff(cutoff, r2, inter, params)
+    elseif cutoff_points(C) == 2
+        r2 > cutoff.sqdist_cutoff && return ustrip(zero(coord_i[1])) * inter.energy_units
+
+        if r2 < cutoff.sqdist_activation
+            pe = potential(inter, r2, inv(r2), params)
+        else
+            pe = potential_cutoff(cutoff, r2, inter, params)
+        end
+    end
+
+    if weight_14
+        return pe * inter.weight_14
+    else
+        return pe
+    end
+end
+
+@fastmath function potential(::CoulombSoftCore, r2, invr2, (coulomb_const, qi, qj, σ, α, λ, p))
+    inv_rsc6 = inv(r2^3 + α * λ^p * σ^6)
+    (coulomb_const * qi * qj) * inv_rsc6 ^ (1/6)
+end

--- a/src/interactions/lennard_jones.jl
+++ b/src/interactions/lennard_jones.jl
@@ -171,7 +171,7 @@ and the force on each atom by
 ```
 
 where ``r_{ij}^{\\text{sc}} = \\left(r_{ij}^6 + \\alpha \\sigma_{ij}^6 \\lambda^p \\right)^{1/6}``. Here, ``\\alpha``,
-``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For we `alpha=1` or `lambda=1`
+``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For `alpha=1` or `lambda=1`
 we get the standard Lennard-Jones potential.
 """
 struct LennardJonesSoftCore{S, C, A, L, P, W, WS, F, E} <: PairwiseInteraction

--- a/src/interactions/lennard_jones.jl
+++ b/src/interactions/lennard_jones.jl
@@ -171,7 +171,7 @@ and the force on each atom by
 ```
 
 where ``r_{ij}^{\\text{sc}} = \\left(r_{ij}^6 + \\alpha \\sigma_{ij}^6 \\lambda^p \\right)^{1/6}``. Here, ``\\alpha``,
-``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For `alpha=1` or `lambda=1`
+``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For `alpha=0` or `lambda=0`
 we get the standard Lennard-Jones potential.
 """
 struct LennardJonesSoftCore{S, C, A, L, P, W, WS, F, E} <: PairwiseInteraction

--- a/src/interactions/lennard_jones.jl
+++ b/src/interactions/lennard_jones.jl
@@ -155,7 +155,7 @@ end
 end
 
 @doc raw"""
-    LennardJonesSoftCore(; cutoff, sc_softness, sc_lambda, sc_power, nl_only, lorentz_mixing, weight_14, weight_solute_solvent,
+    LennardJonesSoftCore(; cutoff, α, λ, p, nl_only, lorentz_mixing, weight_14, weight_solute_solvent,
                  force_units, energy_units, skip_shortcut)
 
 The Lennard-Jones 6-12 interaction between two atoms with a soft core.
@@ -171,14 +171,14 @@ and the force on each atom by
 ```
 
 where ``r_{ij}^{\\text{sc}} = \\left(r_{ij}^6 + \\alpha \\sigma_{ij}^6 \\lambda^p \\right)^{1/6}``. Here, ``\\alpha``,
-``\\lambda``, and ``\\p`` are `sc_softness`, `sc_lambda`, and `sc_power` respectively which are used
-to adjust the functional form of the soft core of the potential.
+``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For we `alpha=1` or `lambda=1`
+we get the standard Lennard-Jones potential.
 """
 struct LennardJonesSoftCore{S, C, A, L, P, W, WS, F, E} <: PairwiseInteraction
     cutoff::C
-    sc_softness::A
-    sc_lambda::L
-    sc_power::P
+    α::A
+    λ::L
+    p::P
     nl_only::Bool
     lorentz_mixing::Bool
     weight_14::W
@@ -189,9 +189,9 @@ end
 
 function LennardJonesSoftCore(;
                         cutoff=NoCutoff(),
-                        sc_softness=1,
-                        sc_lambda=0,
-                        sc_power=2,
+                        α=1,
+                        λ=0,
+                        p=2,
                         nl_only=false,
                         lorentz_mixing=true,
                         weight_14=1,
@@ -199,9 +199,9 @@ function LennardJonesSoftCore(;
                         force_units=u"kJ * mol^-1 * nm^-1",
                         energy_units=u"kJ * mol^-1",
                         skip_shortcut=false)
-    return LennardJonesSoftCore{skip_shortcut, typeof(cutoff), typeof(sc_softness), typeof(sc_lambda), typeof(sc_power),
+    return LennardJonesSoftCore{skip_shortcut, typeof(cutoff), typeof(α), typeof(λ), typeof(p),
                         typeof(weight_14), typeof(weight_solute_solvent), typeof(force_units), typeof(energy_units)}(
-        cutoff, sc_softness, sc_lambda, sc_power, nl_only, lorentz_mixing, weight_14, weight_solute_solvent,
+        cutoff, α, λ, p, nl_only, lorentz_mixing, weight_14, weight_solute_solvent,
         force_units, energy_units)
 end
 
@@ -230,7 +230,7 @@ end
 
     cutoff = inter.cutoff
     σ2 = σ^2
-    params = (σ2, ϵ, inter.sc_softness, inter.sc_lambda, inter.sc_power)
+    params = (σ2, ϵ, inter.α, inter.λ, inter.p)
 
     if cutoff_points(C) == 0
         f = force_divr_nocutoff(inter, r2, inv(r2), params)
@@ -286,7 +286,7 @@ end
 
     cutoff = inter.cutoff
     σ2 = σ^2
-    params = (σ2, ϵ, inter.sc_softness, inter.sc_lambda, inter.sc_power)
+    params = (σ2, ϵ, inter.α, inter.λ, inter.p)
 
     if cutoff_points(C) == 0
         pe = potential(inter, r2, inv(r2), params)

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -7,7 +7,7 @@
     dr12 = vector(c1, c2, boundary)
     dr13 = vector(c1, c3, boundary)
 
-    for inter in (LennardJones(), Mie(m=6, n=12))
+    for inter in (LennardJones(), Mie(m=6, n=12), LennardJonesSoftCore(sc_softness=1, sc_lambda=0, sc_power=2))
         @test isapprox(
             force(inter, dr12, c1, c2, a1, a1, boundary),
             SVector(16.0, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
@@ -52,27 +52,28 @@
         atol=1e-9u"kJ * mol^-1",
     )
 
-    inter = Coulomb()
-    @test isapprox(
-        force(inter, dr12, c1, c2, a1, a1, boundary),
-        SVector(1543.727311, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
-        atol=1e-5u"kJ * mol^-1 * nm^-1",
-    )
-    @test isapprox(
-        force(inter, dr13, c1, c3, a1, a1, boundary),
-        SVector(868.3466125, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
-        atol=1e-5u"kJ * mol^-1 * nm^-1",
-    )
-    @test isapprox(
-        potential_energy(inter, dr12, c1, c2, a1, a1, boundary),
-        463.1181933u"kJ * mol^-1",
-        atol=1e-5u"kJ * mol^-1",
-    )
-    @test isapprox(
-        potential_energy(inter, dr13, c1, c3, a1, a1, boundary),
-        347.338645u"kJ * mol^-1",
-        atol=1e-5u"kJ * mol^-1",
-    )
+    for inter in (Coulomb(), CoulombSoftCore(sc_softness=1, sc_lambda=0, sc_power=2))
+        @test isapprox(
+            force(inter, dr12, c1, c2, a1, a1, boundary),
+            SVector(1543.727311, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
+            atol=1e-5u"kJ * mol^-1 * nm^-1",
+        )
+        @test isapprox(
+            force(inter, dr13, c1, c3, a1, a1, boundary),
+            SVector(868.3466125, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
+            atol=1e-5u"kJ * mol^-1 * nm^-1",
+        )
+        @test isapprox(
+            potential_energy(inter, dr12, c1, c2, a1, a1, boundary),
+            463.1181933u"kJ * mol^-1",
+            atol=1e-5u"kJ * mol^-1",
+        )
+        @test isapprox(
+            potential_energy(inter, dr13, c1, c3, a1, a1, boundary),
+            347.338645u"kJ * mol^-1",
+            atol=1e-5u"kJ * mol^-1",
+        )
+    end
 
     c1_grav = SVector(1.0, 1.0, 1.0)u"m"
     c2_grav = SVector(6.0, 1.0, 1.0)u"m"

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -30,6 +30,28 @@
         )
     end
 
+    inter = LennardJonesSoftCore(α=1, λ=0.5, p=2)
+    @test isapprox(
+        force(inter, dr12, c1, c2, a1, a1, boundary),
+        SVector(6.144, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
+        atol=1e-9u"kJ * mol^-1 * nm^-1",
+    )
+    @test isapprox(
+        force(inter, dr13, c1, c3, a1, a1, boundary),
+        SVector(-1.290499537, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
+        atol=1e-9u"kJ * mol^-1 * nm^-1",
+    )
+    @test isapprox(
+        potential_energy(inter, dr12, c1, c2, a1, a1, boundary),
+        -0.128u"kJ * mol^-1",
+        atol=1e-9u"kJ * mol^-1",
+    )
+    @test isapprox(
+        potential_energy(inter, dr13, c1, c3, a1, a1, boundary),
+        -0.1130893709u"kJ * mol^-1",
+        atol=1e-9u"kJ * mol^-1",
+    )
+
     inter = SoftSphere()
     @test isapprox(
         force(inter, dr12, c1, c2, a1, a1, boundary),
@@ -74,6 +96,28 @@
             atol=1e-5u"kJ * mol^-1",
         )
     end
+
+    inter = CoulombSoftCore(α=1, λ=0.5, p=2)
+    @test isapprox(
+        force(inter, dr12, c1, c2, a1, a1, boundary),
+        SVector(1189.895726, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
+        atol=1e-5u"kJ * mol^-1 * nm^-1",
+    )
+    @test isapprox(
+        force(inter, dr13, c1, c3, a1, a1, boundary),
+        SVector(825.3456507, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
+        atol=1e-5u"kJ * mol^-1 * nm^-1",
+    )
+    @test isapprox(
+        potential_energy(inter, dr12, c1, c2, a1, a1, boundary),
+        446.2108973u"kJ * mol^-1",
+        atol=1e-5u"kJ * mol^-1",
+    )
+    @test isapprox(
+        potential_energy(inter, dr13, c1, c3, a1, a1, boundary),
+        344.8276396u"kJ * mol^-1",
+        atol=1e-5u"kJ * mol^-1",
+    )
 
     c1_grav = SVector(1.0, 1.0, 1.0)u"m"
     c2_grav = SVector(6.0, 1.0, 1.0)u"m"

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -7,7 +7,7 @@
     dr12 = vector(c1, c2, boundary)
     dr13 = vector(c1, c3, boundary)
 
-    for inter in (LennardJones(), Mie(m=6, n=12), LennardJonesSoftCore(sc_softness=1, sc_lambda=0, sc_power=2))
+    for inter in (LennardJones(), Mie(m=6, n=12), LennardJonesSoftCore(α=1, λ=0, p=2))
         @test isapprox(
             force(inter, dr12, c1, c2, a1, a1, boundary),
             SVector(16.0, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",
@@ -52,7 +52,7 @@
         atol=1e-9u"kJ * mol^-1",
     )
 
-    for inter in (Coulomb(), CoulombSoftCore(sc_softness=1, sc_lambda=0, sc_power=2))
+    for inter in (Coulomb(), CoulombSoftCore(α=1, λ=0, p=2))
         @test isapprox(
             force(inter, dr12, c1, c2, a1, a1, boundary),
             SVector(1543.727311, 0.0, 0.0)u"kJ * mol^-1 * nm^-1",


### PR DESCRIPTION
This PR adds soft core version of the Lennard jones and Coulomb pairwise interactions following the expressions in [Beutler, T. C.; Mark, A. E.; van Schaik, R. C.; Gerber, P. R.; van Gunsteren, W. F. Chem. Phys. Lett. 1994, 222, 529−539](https://doi.org/10.1016/0009-2614(94)00397-1).