### PR TITLE
Fix inline math for docstring

### DIFF
--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -123,7 +123,7 @@ end
 The Coulomb electrostatic interaction between two atoms with a soft core.
 The potential energy is defined as
 ```math
-V(r_{ij}) = \frac{q_i q_j}{4 \pi \varepsilon_0 (r_{ij}^6 + \alpha * sigma_{ij}^6 * \lambda^p)^{\frac{1}{6}}}
+V(r_{ij}) = \frac{q_i q_j}{4 \pi \varepsilon_0 (r_{ij}^6 + \alpha * \sigma_{ij}^6 * \lambda^p)^{\frac{1}{6}}}
 ```
 
 Here, ``\alpha``, ``\lambda``, and ``\p`` adjust the functional form of the soft core of the potential. For 

--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -126,7 +126,7 @@ The potential energy is defined as
 V(r_{ij}) = \frac{q_i q_j}{4 \pi \varepsilon_0 (r_{ij}^6 + \alpha * sigma_{ij}^6 * \lambda^p)^{\frac{1}{6}}}
 ```
 
-Here, ``\\alpha``, ``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For 
+Here, ``\alpha``, ``\lambda``, and ``\p`` adjust the functional form of the soft core of the potential. For 
 `alpha=0` or `lambda=0` we get the standard Coulomb potential.
 """
 struct CoulombSoftCore{C, A, L, P, W, T, F, E} <: PairwiseInteraction

--- a/src/interactions/lennard_jones.jl
+++ b/src/interactions/lennard_jones.jl
@@ -170,8 +170,8 @@ and the force on each atom by
 \end{aligned}
 ```
 
-where ``r_{ij}^{\\text{sc}} = \\left(r_{ij}^6 + \\alpha \\sigma_{ij}^6 \\lambda^p \\right)^{1/6}``. Here, ``\\alpha``,
-``\\lambda``, and ``\\p`` adjust the functional form of the soft core of the potential. For `alpha=0` or `lambda=0`
+where ``r_{ij}^{\text{sc}} = \left(r_{ij}^6 + \alpha \sigma_{ij}^6 \lambda^p \right)^{1/6}``. Here, ``\alpha``,
+``\lambda``, and ``\p`` adjust the functional form of the soft core of the potential. For `alpha=0` or `lambda=0`
 we get the standard Lennard-Jones potential.
 """
 struct LennardJonesSoftCore{S, C, A, L, P, W, WS, F, E} <: PairwiseInteraction


### PR DESCRIPTION
Escaping not required as using `@doc raw`.