### PR TITLE
Speed up for softcore potentials and fixes to Mie

### DIFF
--- a/src/interactions/mie.jl
+++ b/src/interactions/mie.jl
@@ -34,7 +34,7 @@ function Mie(;
                 force_units=u"kJ * mol^-1 * nm^-1",
                 energy_units=u"kJ * mol^-1",
                 skip_shortcut=false)
-    mn_fac = convert(typeof(m), (n / (n - m)) * (n / m) ^ (m / (n - m)))
+    m, n, mn_fac = promote(m, n, (n / (n - m)) * (n / m) ^ (m / (n - m)))
     return Mie{skip_shortcut, typeof(cutoff), typeof(m), typeof(force_units), typeof(energy_units)}(
         m, n, cutoff, nl_only, lorentz_mixing, force_units, energy_units, mn_fac)
 end

--- a/src/interactions/mie.jl
+++ b/src/interactions/mie.jl
@@ -34,9 +34,9 @@ function Mie(;
                 force_units=u"kJ * mol^-1 * nm^-1",
                 energy_units=u"kJ * mol^-1",
                 skip_shortcut=false)
-    m, n, mn_fac = promote(m, n, (n / (n - m)) * (n / m) ^ (m / (n - m)))
-    return Mie{skip_shortcut, typeof(cutoff), typeof(m), typeof(force_units), typeof(energy_units)}(
-        m, n, cutoff, nl_only, lorentz_mixing, force_units, energy_units, mn_fac)
+    m_p, n_p, mn_fac = promote(m, n, (n / (n - m)) * (n / m) ^ (m / (n - m)))
+    return Mie{skip_shortcut, typeof(cutoff), typeof(m_p), typeof(force_units), typeof(energy_units)}(
+        m_p, n_p, cutoff, nl_only, lorentz_mixing, force_units, energy_units, mn_fac)
 end
 
 @fastmath @inbounds function force(inter::Mie{S, C, T},


### PR DESCRIPTION
Initial implementation of `LennardJonesSoftCore` and `CoulombSoftCore` was quite slow (several microseconds for single force calculation). This PR add a speed up to make it useable (now the times are about 150ns per force calculation, 3x slower than non-softcore interactions but still way better than before).

Also fixes #94 .