### PR TITLE
adding preliminary AMDGPU support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches:
       - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     tags: '*'
   schedule:
     - cron: '00 04 * * 1' # 4am every Monday
@@ -14,6 +19,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +55,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Joe G Greener <jgreener@hotmail.co.uk>"]
 version = "0.13.0"
 
 [deps]
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 BioStructures = "de9282ab-8554-53be-b2d6-f6c222edabfc"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ UnitfulChainRules = "f31437dd-25a7-4345-875f-756556e6935d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+AMDGPU = "0.4"
 AtomsBase = "0.2"
 BioStructures = "1"
 CUDA = "3"

--- a/src/Molly.jl
+++ b/src/Molly.jl
@@ -7,6 +7,15 @@ import Chemfiles
 using Colors
 using Combinatorics
 using CUDA
+if has_cuda_gpu()
+    CUDA.allowscalar(false)
+end
+
+using AMDGPU
+if has_rocm_gpu()
+    AMDGPU.allowscalar(false)
+end
+
 using DataStructures
 using Distances
 using Distributions

--- a/src/chain_rules.jl
+++ b/src/chain_rules.jl
@@ -109,7 +109,7 @@ function ChainRulesCore.rrule(::typeof(unsafe_getindex), arr, inds)
 end
 
 # Not faster on CPU
-function ChainRulesCore.rrule(::typeof(getindices_i), arr::CuArray, neighbors)
+function ChainRulesCore.rrule(::typeof(getindices_i), arr::AT, neighbors) where AT <: Union{CuArray, ROCArray}
     Y = getindices_i(arr, neighbors)
     @views @inbounds function getindices_i_pullback(Ȳ)
         return NoTangent(), accumulate_bounds(Ȳ, neighbors.atom_bounds_i), nothing
@@ -117,7 +117,7 @@ function ChainRulesCore.rrule(::typeof(getindices_i), arr::CuArray, neighbors)
     return Y, getindices_i_pullback
 end
 
-function ChainRulesCore.rrule(::typeof(getindices_j), arr::CuArray, neighbors)
+function ChainRulesCore.rrule(::typeof(getindices_j), arr::AT, neighbors) where AT <: Union{CuArray, ROCArray}
     Y = getindices_j(arr, neighbors)
     @views @inbounds function getindices_j_pullback(Ȳ)
         return NoTangent(), accumulate_bounds(Ȳ[neighbors.sortperm_j], neighbors.atom_bounds_j), nothing

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -88,9 +88,10 @@ Allows gradients for individual parameters to be tracked.
 Returns atoms, pairwise interactions, specific interaction lists and general
 interactions.
 """
-function inject_gradients(sys, params_dic, gpu::Bool=isa(sys.coords, CuArray))
+function inject_gradients(sys, params_dic,
+                          gpu::Bool=isa(sys.coords, AT)) where AT <: Union{CuArray, ROCArray}
     if gpu
-        atoms_grad = CuArray(inject_atom.(Array(sys.atoms), sys.atoms_data, (params_dic,)))
+        atoms_grad = AT(inject_atom.(Array(sys.atoms), sys.atoms_data, (params_dic,)))
     else
         atoms_grad = inject_atom.(sys.atoms, sys.atoms_data, (params_dic,))
     end
@@ -100,7 +101,7 @@ function inject_gradients(sys, params_dic, gpu::Bool=isa(sys.coords, CuArray))
         pis_grad = sys.pairwise_inters
     end
     if length(sys.specific_inter_lists) > 0
-        sis_grad = inject_interaction_list.(sys.specific_inter_lists, (params_dic,), gpu)
+        sis_grad = inject_interaction_list.(sys.specific_inter_lists, (params_dic,), gpu, AT)
     else
         sis_grad = sys.specific_inter_lists
     end
@@ -127,36 +128,40 @@ function inject_atom(at, at_data, params_dic)
     )
 end
 
-function inject_interaction_list(inter::InteractionList1Atoms, params_dic, gpu)
+function inject_interaction_list(inter::InteractionList1Atoms, params_dic, gpu,
+                                 AT)
     if gpu
-        inters_grad = CuArray(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
+        inters_grad = AT(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
     else
         inters_grad = inject_interaction.(inter.inters, inter.types, (params_dic,))
     end
     InteractionList1Atoms(inter.is, inter.types, inters_grad)
 end
 
-function inject_interaction_list(inter::InteractionList2Atoms, params_dic, gpu)
+function inject_interaction_list(inter::InteractionList2Atoms, params_dic, gpu,
+                                 AT)
     if gpu
-        inters_grad = CuArray(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
+        inters_grad = AT(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
     else
         inters_grad = inject_interaction.(inter.inters, inter.types, (params_dic,))
     end
     InteractionList2Atoms(inter.is, inter.js, inter.types, inters_grad)
 end
 
-function inject_interaction_list(inter::InteractionList3Atoms, params_dic, gpu)
+function inject_interaction_list(inter::InteractionList3Atoms, params_dic, gpu,
+                                 AT)
     if gpu
-        inters_grad = CuArray(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
+        inters_grad = AT(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
     else
         inters_grad = inject_interaction.(inter.inters, inter.types, (params_dic,))
     end
     InteractionList3Atoms(inter.is, inter.js, inter.ks, inter.types, inters_grad)
 end
 
-function inject_interaction_list(inter::InteractionList4Atoms, params_dic, gpu)
+function inject_interaction_list(inter::InteractionList4Atoms, params_dic, gpu,
+                                 AT)
     if gpu
-        inters_grad = CuArray(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
+        inters_grad = AT(inject_interaction.(Array(inter.inters), inter.types, (params_dic,)))
     else
         inters_grad = inject_interaction.(inter.inters, inter.types, (params_dic,))
     end

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -88,8 +88,8 @@ Allows gradients for individual parameters to be tracked.
 Returns atoms, pairwise interactions, specific interaction lists and general
 interactions.
 """
-function inject_gradients(sys, params_dic,
-                          gpu::Bool=isa(sys.coords, AT)) where AT <: Union{CuArray, ROCArray}
+function inject_gradients(sys, params_dic; AT = find_array_type(sys.coords),
+                          gpu::Bool = (AT <: Union{CuArray, ROCArray}))
     if gpu
         atoms_grad = AT(inject_atom.(Array(sys.atoms), sys.atoms_data, (params_dic,)))
     else

--- a/src/interactions/implicit_solvent.jl
+++ b/src/interactions/implicit_solvent.jl
@@ -410,6 +410,10 @@ function ImplicitSolventOBC(atoms::AbstractArray{Atom{T, M, D, E}},
         or = CuArray(offset_radii)
         sor = CuArray(scaled_offset_radii)
         is, js = CuArray(inds_i), CuArray(inds_j)
+    elseif isa(atoms, ROCArray)
+        or = ROCArray(offset_radii)
+        sor = ROCArray(scaled_offset_radii)
+        is, js = ROCArray(inds_i), ROCArrayArray(inds_j)
     else
         or = offset_radii
         sor = scaled_offset_radii
@@ -555,6 +559,12 @@ function ImplicitSolventGBN2(atoms::AbstractArray{Atom{T, M, D, E}},
         is, js = CuArray(inds_i), CuArray(inds_j)
         d0s, m0s = CuArray(table_d0), CuArray(table_m0)
         αs, βs, γs = CuArray(αs_cpu), CuArray(βs_cpu), CuArray(γs_cpu)
+    elseif isa(atoms, ROCArray)
+        or = ROCArray(offset_radii)
+        sor = ROCArray(scaled_offset_radii)
+        is, js = ROCArray(inds_i), ROCArray(inds_j)
+        d0s, m0s = ROCArray(table_d0), ROCArray(table_m0)
+        αs, βs, γs = ROCArray(αs_cpu), ROCArray(βs_cpu), ROCArray(γs_cpu)
     else
         or = offset_radii
         sor = scaled_offset_radii

--- a/src/neighbors.jl
+++ b/src/neighbors.jl
@@ -114,6 +114,10 @@ function DistanceVecNeighborFinder(;
         is = CuArray(hcat([collect(1:n_atoms) for i in 1:n_atoms]...))
         js = CuArray(permutedims(is, (2, 1)))
         m14 = CuArray(matrix_14)
+    elsif isa(nb_matrix, ROCArray)
+        is = ROCArray(hcat([collect(1:n_atoms) for i in 1:n_atoms]...))
+        js = ROCArray(permutedims(is, (2, 1)))
+        m14 = ROCArray(matrix_14)
     else
         is = hcat([collect(1:n_atoms) for i in 1:n_atoms]...)
         js = permutedims(is, (2, 1))

--- a/src/neighbors.jl
+++ b/src/neighbors.jl
@@ -114,7 +114,7 @@ function DistanceVecNeighborFinder(;
         is = CuArray(hcat([collect(1:n_atoms) for i in 1:n_atoms]...))
         js = CuArray(permutedims(is, (2, 1)))
         m14 = CuArray(matrix_14)
-    elsif isa(nb_matrix, ROCArray)
+    elseif isa(nb_matrix, ROCArray)
         is = ROCArray(hcat([collect(1:n_atoms) for i in 1:n_atoms]...))
         js = ROCArray(permutedims(is, (2, 1)))
         m14 = ROCArray(matrix_14)

--- a/src/types.jl
+++ b/src/types.jl
@@ -662,9 +662,9 @@ masses(s::Union{System, ReplicaSystem}) = mass.(s.atoms)
 
 # Move an array to the GPU depending on whether the system is on the GPU
 move_array(arr, ::System{D, G, T, false}) where {D, G, T} = arr
-move_array(arr::AT, ::System{D, G, T, true }) where {AT <: Union{CuArray,
-                                                                 ROCArray},
-                                                     D, G, T} = AT(arr)
+function move_array(arr, sys::System{D, G, T, true }) where {D, G, T}
+    find_array_type(sys.coords)(arr)
+end
 
 AtomsBase.species_type(s::Union{System, ReplicaSystem}) = eltype(s.atoms)
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -189,8 +189,11 @@ end
     coords_1 = SVector{3, Float64}.(eachcol(cm_1)) / 10 * u"nm"
     coords_2 = SVector{3, Float64}.(eachcol(cm_2)) / 10 * u"nm"
     @test rmsd(coords_1, coords_2) ≈ 2.54859467758795u"Å"
-    if run_gpu_tests
+    if run_cuda_tests
         @test rmsd(CuArray(coords_1), CuArray(coords_2)) ≈ 2.54859467758795u"Å"
+    end
+    if run_rocm_tests
+        @test rmsd(ROCArray(coords_1), ROCArray(coords_2)) ≈ 2.54859467758795u"Å"
     end
 
     bb_atoms = BioStructures.collectatoms(struc[1], BioStructures.backboneselector)

--- a/test/minimization.jl
+++ b/test/minimization.jl
@@ -43,25 +43,27 @@
                     atol=1e-4u"kJ * mol^-1")
 
     if run_gpu_tests
-        coords = CuArray([
-            SVector(1.0, 1.0, 1.0)u"nm",
-            SVector(1.6, 1.0, 1.0)u"nm",
-            SVector(1.4, 1.6, 1.0)u"nm",
-        ])
-        sys = System(
-            atoms=CuArray([Atom(σ=(0.4 / (2 ^ (1 / 6)))u"nm", ϵ=1.0u"kJ * mol^-1") for i in 1:3]),
-            pairwise_inters=(LennardJones(),),
-            coords=coords,
-            boundary=CubicBoundary(5.0u"nm", 5.0u"nm", 5.0u"nm"),
-        )
-        sim = SteepestDescentMinimizer(tol=1.0u"kJ * mol^-1 * nm^-1")
+        for AT in gpu_array_types
+            coords = AT([
+                SVector(1.0, 1.0, 1.0)u"nm",
+                SVector(1.6, 1.0, 1.0)u"nm",
+                SVector(1.4, 1.6, 1.0)u"nm",
+            ])
+            sys = System(
+                atoms=AT([Atom(σ=(0.4 / (2 ^ (1 / 6)))u"nm", ϵ=1.0u"kJ * mol^-1") for i in 1:3]),
+                pairwise_inters=(LennardJones(),),
+                coords=coords,
+                boundary=CubicBoundary(5.0u"nm", 5.0u"nm", 5.0u"nm"),
+            )
+            sim = SteepestDescentMinimizer(tol=1.0u"kJ * mol^-1 * nm^-1")
     
-        simulate!(sys, sim)
-        dists = distances(sys.coords, sys.boundary)
-        dists_flat = dists[triu(trues(3, 3), 1)]
-        @test all(x -> isapprox(x, 0.4u"nm"; atol=1e-3u"nm"), dists_flat)
-        neighbors = find_neighbors(sys)
-        @test isapprox(potential_energy(sys, neighbors), -3.0u"kJ * mol^-1";
-                        atol=1e-4u"kJ * mol^-1")
+            simulate!(sys, sim)
+            dists = distances(sys.coords, sys.boundary)
+            dists_flat = dists[triu(trues(3, 3), 1)]
+            @test all(x -> isapprox(x, 0.4u"nm"; atol=1e-3u"nm"), dists_flat)
+            neighbors = find_neighbors(sys)
+            @test isapprox(potential_energy(sys, neighbors), -3.0u"kJ * mol^-1";
+                            atol=1e-4u"kJ * mol^-1")
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,7 +56,7 @@ CUDA.allowscalar(false) # Check that we never do scalar indexing on the GPU
 run_rocm_tests = AMDGPU.functional()
 if run_rocm_tests
     AMDGPU.default_device_id!(parse(Int, DEVICE)+1)
-    @info "The GPU tests will be run on device " * string(DEVICE + 1)
+    @info "The GPU tests will be run on device " * string(parse(Int, DEVICE) + 1)
 else
     @warn "The ROCM tests will not be run as a ROCM-enabled device is not availa
 ble"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,15 +42,37 @@ else
     @warn "The parallel tests will not be run as Julia is running on 1 thread"
 end
 
-run_gpu_tests = CUDA.functional()
-if run_gpu_tests
+run_cuda_tests = CUDA.functional()
+if run_cuda_tests
     device!(parse(Int, DEVICE))
     @info "The GPU tests will be run on device $DEVICE"
 else
-    @warn "The GPU tests will not be run as a CUDA-enabled device is not available"
+    @warn "The CUDA tests will not be run as a CUDA-enabled device is not available"
 end
 
 CUDA.allowscalar(false) # Check that we never do scalar indexing on the GPU
+
+run_rocm_tests = AMDGPU.functional()
+if run_rocm_tests
+    device!(parse(Int, DEVICE))
+    @info "The GPU tests will be run on device $DEVICE"
+else
+    @warn "The ROCM tests will not be run as a ROCM-enabled device is not availa
+ble"
+end
+
+AMDGPU.allowscalar(false)
+
+run_gpu_tests = run_cuda_tests || run_rocm_tests
+gpu_array_types = []
+if run_gpu_tests
+    if run_cuda_tests
+        push!(gpu_array_types, CuArray)
+    end
+    if run_cuda_tests
+        push!(gpu_array_types, ROCArray)
+    end
+end
 
 data_dir = normpath(@__DIR__, "..", "data")
 ff_dir = joinpath(data_dir, "force_fields")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,8 +58,7 @@ if run_rocm_tests
     AMDGPU.default_device_id!(parse(Int, DEVICE)+1)
     @info "The GPU tests will be run on device " * string(parse(Int, DEVICE) + 1)
 else
-    @warn "The ROCM tests will not be run as a ROCM-enabled device is not availa
-ble"
+    @warn "The ROCM tests will not be run as a ROCM-enabled device is not available"
 end
 
 AMDGPU.allowscalar(false)
@@ -90,8 +89,8 @@ if GROUP == "All"
         undefined_exports=false,
     )
 
-    #include("basic.jl")
-    #include("interactions.jl")
+    include("basic.jl")
+    include("interactions.jl")
     include("minimization.jl")
     include("simulation.jl")
     include("agent.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,7 +70,7 @@ if run_gpu_tests
     if run_cuda_tests
         push!(gpu_array_types, CuArray)
     end
-    if run_cuda_tests
+    if run_rocm_tests
         push!(gpu_array_types, ROCArray)
     end
 end
@@ -90,8 +90,8 @@ if GROUP == "All"
         undefined_exports=false,
     )
 
-    include("basic.jl")
-    include("interactions.jl")
+    #include("basic.jl")
+    #include("interactions.jl")
     include("minimization.jl")
     include("simulation.jl")
     include("agent.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Molly
 using Aqua
 import BioStructures # Imported to avoid clashing names
 using CUDA
+using AMDGPU
 using FiniteDifferences
 using ForwardDiff
 using Zygote
@@ -54,8 +55,8 @@ CUDA.allowscalar(false) # Check that we never do scalar indexing on the GPU
 
 run_rocm_tests = AMDGPU.functional()
 if run_rocm_tests
-    device!(parse(Int, DEVICE))
-    @info "The GPU tests will be run on device $DEVICE"
+    AMDGPU.default_device_id!(parse(Int, DEVICE)+1)
+    @info "The GPU tests will be run on device " * string(DEVICE + 1)
 else
     @warn "The ROCM tests will not be run as a ROCM-enabled device is not availa
 ble"

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -37,7 +37,7 @@
     end
 
     function test_grad(gpu::Bool, forward::Bool, f32::Bool, pis::Bool,
-                        sis::Bool, obc2::Bool, gbn2::Bool)
+                        sis::Bool, obc2::Bool, gbn2::Bool; AT = Array)
         n_atoms = 50
         n_steps = 100
         atom_mass = f32 ? 10.0f0 : 10.0
@@ -75,7 +75,7 @@
             collect(16:30),
             collect(31:45),
             fill("", 15),
-            gpu ? CuArray(angles_inner) : angles_inner,
+            gpu ? AT(angles_inner) : angles_inner,
         )
         torsions_inner = [PeriodicTorsion(
                 periodicities=[1, 2, 3],
@@ -89,12 +89,12 @@
             collect(21:30),
             collect(31:40),
             fill("", 10),
-            gpu ? CuArray(torsions_inner) : torsions_inner,
+            gpu ? AT(torsions_inner) : torsions_inner,
         )
         atoms_setup = [Atom(charge=f32 ? 0.0f0 : 0.0, σ=f32 ? 0.0f0 : 0.0) for i in 1:n_atoms]
         if obc2
             imp_obc2 = ImplicitSolventOBC(
-                gpu ? CuArray(atoms_setup) : atoms_setup,
+                gpu ? AT(atoms_setup) : atoms_setup,
                 [AtomData(element="O") for i in 1:n_atoms],
                 InteractionList2Atoms(bond_is, bond_js, [""], nothing);
                 use_OBC2=true,
@@ -102,7 +102,7 @@
             general_inters = (imp_obc2,)
         elseif gbn2
             imp_gbn2 = ImplicitSolventGBN2(
-                gpu ? CuArray(atoms_setup) : atoms_setup,
+                gpu ? AT(atoms_setup) : atoms_setup,
                 [AtomData(element="O") for i in 1:n_atoms],
                 InteractionList2Atoms(bond_is, bond_js, [""], nothing),
             )
@@ -111,7 +111,7 @@
             general_inters = ()
         end
         neighbor_finder = DistanceVecNeighborFinder(
-            nb_matrix=gpu ? CuArray(trues(n_atoms, n_atoms)) : trues(n_atoms, n_atoms),
+            nb_matrix=gpu ? AT(trues(n_atoms, n_atoms)) : trues(n_atoms, n_atoms),
             n_steps=10,
             dist_cutoff=f32 ? 1.5f0 : 1.5,
         )
@@ -128,18 +128,18 @@
                 bond_is,
                 bond_js,
                 fill("", length(bonds_inner)),
-                gpu ? CuArray(bonds_inner) : bonds_inner,
+                gpu ? AT(bonds_inner) : bonds_inner,
             )
             cs = deepcopy(forward ? coords_dual : coords)
             vs = deepcopy(forward ? velocities_dual : velocities)
 
             s = System(
-                atoms=gpu ? CuArray(atoms) : atoms,
+                atoms=gpu ? AT(atoms) : atoms,
                 pairwise_inters=pairwise_inters,
                 specific_inter_lists=sis ? (bonds, angles, torsions) : (),
                 general_inters=general_inters,
-                coords=gpu ? CuArray(cs) : cs,
-                velocities=gpu ? CuArray(vs) : vs,
+                coords=gpu ? AT(cs) : cs,
+                velocities=gpu ? AT(vs) : vs,
                 boundary=boundary,
                 neighbor_finder=neighbor_finder,
                 gpu_diff_safe=true,
@@ -165,15 +165,27 @@
         ("cpu gbn2"        , [false, false, false, true , true , false, true ], 0.1 , 0.25),
         ("cpu gbn2 forward", [false, true , false, true , true , false, true ], 0.02, 0.02),
     ]
-    if run_gpu_tests #                    gpu    fwd    f32    pis    sis    obc2   gbn2
-        push!(runs, ("gpu"             , [true , false, false, true , true , false, false], 0.25, 20.0))
-        push!(runs, ("gpu forward"     , [true , true , false, true , true , false, false], 0.01, 0.01))
-        push!(runs, ("gpu f32"         , [true , false, true , true , true , false, false], 0.5 , 50.0))
-        push!(runs, ("gpu nospecific"  , [true , false, false, true , false, false, false], 0.25, 0.0 ))
-        push!(runs, ("gpu nopairwise"  , [true , false, false, false, true , false, false], 0.0 , 10.0))
-        push!(runs, ("gpu obc2"        , [true , false, false, true , true , true , false], 0.25, 20.0))
-        push!(runs, ("gpu gbn2"        , [true , false, false, true , true , false, true ], 0.25, 20.0))
-        push!(runs, ("gpu gbn2 forward", [true , true , false, true , true , false, true ], 0.02, 0.02))
+    if run_gpu_tests #                         gpu    fwd    f32    pis    sis    obc2   gbn2
+        if run_cuda_tests
+            push!(runs, ("cuda"             , [true , false, false, true , true , false, false, AT = CuArray], 0.25, 20.0))
+            push!(runs, ("cuda forward"     , [true , true , false, true , true , false, false, AT = CuArray], 0.01, 0.01))
+            push!(runs, ("cuda f32"         , [true , false, true , true , true , false, false, AT = CuArray], 0.5 , 50.0))
+            push!(runs, ("cuda nospecific"  , [true , false, false, true , false, false, false, AT = CuArray], 0.25, 0.0 ))
+            push!(runs, ("cuda nopairwise"  , [true , false, false, false, true , false, false, AT = CuArray], 0.0 , 10.0))
+            push!(runs, ("cuda obc2"        , [true , false, false, true , true , true , false, AT = CuArray], 0.25, 20.0))
+            push!(runs, ("cuda gbn2"        , [true , false, false, true , true , false, true , AT = CuArray], 0.25, 20.0))
+            push!(runs, ("cuda gbn2 forward", [true , true , false, true , true , false, true , AT = CuArray], 0.02, 0.02))
+        end
+        if run_rocm_tests
+            push!(runs, ("rocm"             , [true , false, false, true , true , false, false, AT = ROCArray], 0.25, 20.0))
+            push!(runs, ("rocm forward"     , [true , true , false, true , true , false, false, AT = ROCArray], 0.01, 0.01))
+            push!(runs, ("rocm f32"         , [true , false, true , true , true , false, false, AT = ROCArray], 0.5 , 50.0))
+            push!(runs, ("rocm nospecific"  , [true , false, false, true , false, false, false, AT = ROCArray], 0.25, 0.0 ))
+            push!(runs, ("rocm nopairwise"  , [true , false, false, false, true , false, false, AT = ROCArray], 0.0 , 10.0))
+            push!(runs, ("rocm obc2"        , [true , false, false, true , true , true , false, AT = ROCArray], 0.25, 20.0))
+            push!(runs, ("rocm gbn2"        , [true , false, false, true , true , false, true , AT = ROCArray], 0.25, 20.0))
+            push!(runs, ("rocm gbn2 forward", [true , true , false, true , true , false, true , AT = ROCArray], 0.02, 0.02))
+        end
     end
 
     for (name, args, tol_σ, tol_k) in runs


### PR DESCRIPTION
I am still running the tests, so this PR is still a draft and might change in the next few days, but it adds preliminary support for AMDGPU devices.

There were a few small things to note:
1. I modified every part of the code with `CuArray` to use an Array Type `AT` value instead. There were a few places (such as in `zygote.jl` with internal functions that were only used for the GPU. In these cases, `AT` became a function argument. In most cases, `AT` could be created without any change to the function calls, themselves.
2. In a few cases (such as `interactions/implicit_solver.jl`), I added a new conditional with `ROCArray` instead of `CuArray`
3. In a few cases, the  `System(...)` call was modified to try and figure out what device you wanted to use if you set `gpu` to true, but will default to `CUDA` if both GPUs are present and things are left unspecified
4. The tests were modified to have `run_cuda_tests` and `run_rocm_tests`. It will then populate the array `gpu_array_types` with `CuArray`, `ROCArray`, or both. I tried to modify all the tests to use the array types from this array.

Again, still messing around with things now, but thought I would put the draft PR up in the case that there are design decisions to talk about.