### PR TITLE
Hotfix for Julia 1.9

### DIFF
--- a/src/zygote.jl
+++ b/src/zygote.jl
@@ -3,7 +3,6 @@
 # Here be dragons
 
 using ForwardDiff: Chunk, Dual, partials, value
-using ForwardDiff.ForwardDiffStaticArraysExt: dualize
 using Zygote: unbroadcast
 
 iszero_value(x::Dual) = iszero(value(x))
@@ -187,8 +186,9 @@ Zygote.∇getindex(x::CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> be
     return Zygote._project(x, CuArray(dx)), nothing
 end
 
+# Modified version of ForwardDiff.ForwardDiffStaticArraysExt.dualize
 # Extend to add extra empty partials before (B) and after (A) the SVector partials
-@generated function ForwardDiff.ForwardDiffStaticArraysExt.dualize(::Type{T}, x::StaticArray, ::Val{B}, ::Val{A}) where {T, B, A}
+@generated function dualize(::Type{T}, x::StaticArray, ::Val{B}, ::Val{A}) where {T, B, A}
     N = length(x)
     dx = Expr(:tuple, [:(Dual{T}(x[$i], chunk, Val{$i + $B}())) for i in 1:N]...)
     V = StaticArrays.similar_type(x, Dual{T, eltype(x), N + B + A})


### PR DESCRIPTION
Using the new extension system, it seems the `dualize` function defined in `FordwardDiff`'s `ForwardDiffStaticArraysExt` extension module is not importable (at least I could not manage to do it).

However, since the signature defined here (in Molly) is only used from within Zygote, I supposed it's safe to simply define it independent of `ForwardDiff`'s `dualize`. 
Maybe this `dualize` could/should be called `offset_dualize` to clearly distinguish it?

Using this little trick allowed me to load Molly on 1.9.0rc1.
However, I couldn't run `Pkg.test` because it fails due to some GL stuff not working (running it on a remote node without even an display server) and I was not using the differentiable capabilities so far, so I cannot say anything about correctness.