### PR TITLE
Add Side Length checker

### DIFF
--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -27,17 +27,15 @@ Setting one or more values to `Inf` gives no boundary in that dimension.
 """
 struct CubicBoundary{T}
     side_lengths::SVector{3, T}
+    CubicBoundary(side_lengths::SVector{3, E}) where E = (
+        all(a -> a >= 0*unit(a),  side_lengths) ?
+        new{E}(side_lengths) :
+        throw(DomainError("Side lengths need to be positive, got $side_lengths"))
+    )
 end
 
-function CubicBoundary(x, y, z)
-    @assert all(a -> a > 0*unit(a), [x, y, z]) "Side lengths need to be larger than 0, got [$x,$y,$z]"
-    CubicBoundary(SVector{3}(x, y, z))
-end
-
-function CubicBoundary(arr)
-    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0, got $arr"
-    CubicBoundary(SVector{3}(arr))
-end
+CubicBoundary(x, y, z) = CubicBoundary(SVector{3}(x, y, z))
+CubicBoundary(arr) = CubicBoundary(SVector{3}(arr))
 
 Base.getindex(b::CubicBoundary, i::Integer) = b.side_lengths[i]
 Base.firstindex(b::CubicBoundary) = b.side_lengths[1]
@@ -52,16 +50,15 @@ Setting one or more values to `Inf` gives no boundary in that dimension.
 """
 struct RectangularBoundary{T}
     side_lengths::SVector{2, T}
+    RectangularBoundary(side_lengths::SVector{2, E}) where E = (
+        all(a -> a >= 0 * unit(a), side_lengths) ?
+        new{E}(side_lengths) :
+        throw(DomainError("Side lengths need to be positive, got $side_lengths"))
+    )
 end
 
-function RectangularBoundary(x, y)
-    @assert all(a -> a > 0*unit(a), [x, y]) "Side lengths need to be larger than 0, got [$x, $y]"
-    RectangularBoundary(SVector{2}(x, y))
-end
-function RectangularBoundary(arr)
-    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0, got $arr"
-    RectangularBoundary(SVector{2}(arr))
-end
+RectangularBoundary(x, y) = RectangularBoundary(SVector{2}(x, y))
+RectangularBoundary(arr) = RectangularBoundary(SVector{2}(arr))
 
 Base.getindex(b::RectangularBoundary, i::Integer) = b.side_lengths[i]
 Base.firstindex(b::RectangularBoundary) = b.side_lengths[1]

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -30,12 +30,12 @@ struct CubicBoundary{T}
 end
 
 function CubicBoundary(x, y, z)
-    @assert all(a -> a > 0, [x, y, z]) "Side lengths need to be larger than 0"
+    @assert all(a -> a > 0*unit(a), [x, y, z]) "Side lengths need to be larger than 0"
     CubicBoundary(SVector{3}(x, y, z))
 end
 
 function CubicBoundary(arr)
-    @assert all(x -> x > 0, arr) "Side lengths need to be larger than 0"
+    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0"
     CubicBoundary(SVector{3}(arr))
 end
 
@@ -55,11 +55,11 @@ struct RectangularBoundary{T}
 end
 
 function RectangularBoundary(x, y)
-    @assert all(a -> a > 0, [x, y]) "Side lengths need to be larger than 0"
+    @assert all(a -> a > 0*unit(a), [x, y]) "Side lengths need to be larger than 0"
     RectangularBoundary(SVector{2}(x, y))
 end
 function RectangularBoundary(arr)
-    @assert all(x -> x > 0, arr) "Side lengths need to be larger than 0"
+    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0"
     RectangularBoundary(SVector{2}(arr))
 end
 

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -27,11 +27,12 @@ Setting one or more values to `Inf` gives no boundary in that dimension.
 """
 struct CubicBoundary{T}
     side_lengths::SVector{3, T}
-    CubicBoundary(side_lengths::SVector{3, E}) where E = (
-        all(a -> a >= 0*unit(a),  side_lengths) ?
-        new{E}(side_lengths) :
-        throw(DomainError("Side lengths need to be positive, got $side_lengths"))
-    )
+    function CubicBoundary(side_lengths::SVector{3, E}) where E
+        if any(a -> a < zero(a),  side_lengths)
+            throw(DomainError("Side lengths can't be negative, got $side_lengths"))
+        end
+        new{E}(side_lengths)
+    end
 end
 
 CubicBoundary(x, y, z) = CubicBoundary(SVector{3}(x, y, z))
@@ -50,11 +51,12 @@ Setting one or more values to `Inf` gives no boundary in that dimension.
 """
 struct RectangularBoundary{T}
     side_lengths::SVector{2, T}
-    RectangularBoundary(side_lengths::SVector{2, E}) where E = (
-        all(a -> a >= 0 * unit(a), side_lengths) ?
-        new{E}(side_lengths) :
-        throw(DomainError("Side lengths need to be positive, got $side_lengths"))
-    )
+    function RectangularBoundary(side_lengths::SVector{2, E}) where E
+        if any(a -> a < zero(a), side_lengths)
+            throw(DomainError("Side lengths can't be negative, got $side_lengths"))
+        end
+        new{E}(side_lengths)
+    end
 end
 
 RectangularBoundary(x, y) = RectangularBoundary(SVector{2}(x, y))

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -30,12 +30,12 @@ struct CubicBoundary{T}
 end
 
 function CubicBoundary(x, y, z)
-    @assert all(a -> a > 0*unit(a), [x, y, z]) "Side lengths need to be larger than 0"
+    @assert all(a -> a > 0*unit(a), [x, y, z]) "Side lengths need to be larger than 0, got [$x,$y,$z]"
     CubicBoundary(SVector{3}(x, y, z))
 end
 
 function CubicBoundary(arr)
-    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0"
+    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0, got $arr"
     CubicBoundary(SVector{3}(arr))
 end
 
@@ -55,11 +55,11 @@ struct RectangularBoundary{T}
 end
 
 function RectangularBoundary(x, y)
-    @assert all(a -> a > 0*unit(a), [x, y]) "Side lengths need to be larger than 0"
+    @assert all(a -> a > 0*unit(a), [x, y]) "Side lengths need to be larger than 0, got [$x, $y]"
     RectangularBoundary(SVector{2}(x, y))
 end
 function RectangularBoundary(arr)
-    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0"
+    @assert all(x -> x > 0*unit(x), arr) "Side lengths need to be larger than 0, got $arr"
     RectangularBoundary(SVector{2}(arr))
 end
 

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -29,8 +29,15 @@ struct CubicBoundary{T}
     side_lengths::SVector{3, T}
 end
 
-CubicBoundary(x, y, z) = CubicBoundary(SVector{3}(x, y, z))
-CubicBoundary(arr) = CubicBoundary(SVector{3}(arr))
+function CubicBoundary(x, y, z)
+    @assert all(a -> a > 0, [x, y, z]) "Side lengths need to be larger than 0"
+    CubicBoundary(SVector{3}(x, y, z))
+end
+
+function CubicBoundary(arr)
+    @assert all(x -> x > 0, arr) "Side lengths need to be larger than 0"
+    CubicBoundary(SVector{3}(arr))
+end
 
 Base.getindex(b::CubicBoundary, i::Integer) = b.side_lengths[i]
 Base.firstindex(b::CubicBoundary) = b.side_lengths[1]
@@ -47,8 +54,14 @@ struct RectangularBoundary{T}
     side_lengths::SVector{2, T}
 end
 
-RectangularBoundary(x, y) = RectangularBoundary(SVector{2}(x, y))
-RectangularBoundary(arr) = RectangularBoundary(SVector{2}(arr))
+function RectangularBoundary(x, y)
+    @assert all(a -> a > 0, [x, y]) "Side lengths need to be larger than 0"
+    RectangularBoundary(SVector{2}(x, y))
+end
+function RectangularBoundary(arr)
+    @assert all(x -> x > 0, arr) "Side lengths need to be larger than 0"
+    RectangularBoundary(SVector{2}(arr))
+end
 
 Base.getindex(b::RectangularBoundary, i::Integer) = b.side_lengths[i]
 Base.firstindex(b::RectangularBoundary) = b.side_lengths[1]

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -46,11 +46,13 @@
     @test box_volume(b) == 120.0u"nm^3"
     @test box_center(b) == SVector(2.0, 2.5, 3.0)u"nm"
     @test_throws AssertionError CubicBoundary(-4.0u"nm", 5.0u"nm", 6.0u"nm")
+    @test_throws AssertionError CubicBoundary([0u"nm", 5.0u"nm", 6.0u"nm"])
 
     b = RectangularBoundary(4.0u"m", 5.0u"m")
     @test box_volume(b) == 20.0u"m^2"
     @test box_center(b) == SVector(2.0, 2.5)u"m"
     @test_throws AssertionError RectangularBoundary(-4.0u"nm", 5.0u"nm")
+    @test_throws AssertionError RectangularBoundary([0u"nm", 5.0u"nm"])
 
     b = TriclinicBoundary(SVector(2.2, 2.0, 1.8)u"nm", deg2rad.(SVector(50.0, 40.0, 60.0)))
     @test isapprox(b.basis_vectors[1], SVector(2.2      , 0.0      , 0.0      )u"nm", atol=1e-6u"nm")

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -45,10 +45,12 @@
     b = CubicBoundary(4.0u"nm", 5.0u"nm", 6.0u"nm")
     @test box_volume(b) == 120.0u"nm^3"
     @test box_center(b) == SVector(2.0, 2.5, 3.0)u"nm"
+    @test_throws AssertionError CubicBoundary(-4.0u"nm", 5.0u"nm", 6.0u"nm")
 
     b = RectangularBoundary(4.0u"m", 5.0u"m")
     @test box_volume(b) == 20.0u"m^2"
     @test box_center(b) == SVector(2.0, 2.5)u"m"
+    @test_throws AssertionError RectangularBoundary(-4.0u"nm", 5.0u"nm")
 
     b = TriclinicBoundary(SVector(2.2, 2.0, 1.8)u"nm", deg2rad.(SVector(50.0, 40.0, 60.0)))
     @test isapprox(b.basis_vectors[1], SVector(2.2      , 0.0      , 0.0      )u"nm", atol=1e-6u"nm")

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -45,14 +45,12 @@
     b = CubicBoundary(4.0u"nm", 5.0u"nm", 6.0u"nm")
     @test box_volume(b) == 120.0u"nm^3"
     @test box_center(b) == SVector(2.0, 2.5, 3.0)u"nm"
-    @test_throws AssertionError CubicBoundary(-4.0u"nm", 5.0u"nm", 6.0u"nm")
-    @test_throws AssertionError CubicBoundary([0u"nm", 5.0u"nm", 6.0u"nm"])
+    @test_throws DomainError CubicBoundary(-4.0u"nm", 5.0u"nm", 6.0u"nm")
 
     b = RectangularBoundary(4.0u"m", 5.0u"m")
     @test box_volume(b) == 20.0u"m^2"
     @test box_center(b) == SVector(2.0, 2.5)u"m"
-    @test_throws AssertionError RectangularBoundary(-4.0u"nm", 5.0u"nm")
-    @test_throws AssertionError RectangularBoundary([0u"nm", 5.0u"nm"])
+    @test_throws DomainError RectangularBoundary(-4.0u"nm", 5.0u"nm")
 
     b = TriclinicBoundary(SVector(2.2, 2.0, 1.8)u"nm", deg2rad.(SVector(50.0, 40.0, 60.0)))
     @test isapprox(b.basis_vectors[1], SVector(2.2      , 0.0      , 0.0      )u"nm", atol=1e-6u"nm")


### PR DESCRIPTION
I added checks for side length to be greater than zero for `CubicBoundary` and `RectangularBoundary`.

I did two unit tests locally. One of them gave an error shown below. Looks like zygote might create a `CubicBoundary` with negative side length. However, I was not able to reproduce this again. 
```
Gradients: Error During Test at /Users/yushengzhao/projects/Molly.jl/test/zygote.jl:1
  Got exception outside of a @test
  AssertionError: Side lengths need to be larger than 0
  Stacktrace:
    [1] CubicBoundary
      @ ~/projects/Molly.jl/src/spatial.jl:38 [inlined]
    [2] accum(x::NamedTuple{(:side_lengths,), Tuple{SizedVector{3, Float64, Vector{Float64}}}}, y::SVector{3, Float64})
      @ Molly ~/projects/Molly.jl/src/zygote.jl:137
    [3] (::Zygote.var"#back#291"{:contents, Zygote.Context{false}, Core.Box, CubicBoundary{Float64}})(Δ::SVector{3, Float64})
      @ Zygote ~/.julia/packages/Zygote/xGkZ5/src/lib/lib.jl:237
    [4] (::Zygote.var"#2149#back#292"{Zygote.var"#back#291"{:contents, Zygote.Context{false}, Core.Box, CubicBoundary{Float64}}})(Δ::SVector{3, Float64})
      @ Zygote ~/.julia/packages/ZygoteRules/OgCVT/src/adjoint.jl:71
    [5] Pullback
      @ ~/projects/Molly.jl/test/zygote.jl:136 [inlined]
    [6] (::typeof(∂(λ)))(Δ::Float64)
      @ Zygote ~/.julia/packages/Zygote/xGkZ5/src/compiler/interface2.jl:0
    [7] (::Zygote.var"#68#69"{typeof(∂(λ))})(Δ::Float64)
      @ Zygote ~/.julia/packages/Zygote/xGkZ5/src/compiler/interface.jl:45
    [8] gradient(::Function, ::Float64, ::Vararg{Float64})
      @ Zygote ~/.julia/packages/Zygote/xGkZ5/src/compiler/interface.jl:97
    [9] macro expansion
      @ ~/projects/Molly.jl/test/zygote.jl:196 [inlined]
   [10] macro expansion
      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
   [11] top-level scope
      @ ~/projects/Molly.jl/test/zygote.jl:2
   [12] include(fname::String)
      @ Base.MainInclude ./client.jl:476
   [13] top-level scope
      @ ~/projects/Molly.jl/test/runtests.jl:82
   [14] include(fname::String)
      @ Base.MainInclude ./client.jl:476
   [15] top-level scope
      @ none:6
   [16] eval
      @ ./boot.jl:368 [inlined]
   [17] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:276
   [18] _start()
      @ Base ./client.jl:522
Test Summary: | Pass  Error  Total     Time
Gradients     |    9      1     10  1m41.3s
ERROR: LoadError: Some tests did not pass: 9 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /Users/yushengzhao/projects/Molly.jl/test/zygote.jl:1
in expression starting at /Users/yushengzhao/projects/Molly.jl/test/runtests.jl:81
ERROR: Package Molly errored during testing
```
