### PR TITLE
Fix GitHub Pages Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=https://juliamolsim.github.io/Molly.jl/dev/" />
+    <meta http-equiv="refresh" content="0; url=https://juliamolsim.github.io/Molly.jl/stable/" />
   </head>
 
   <body>
-    <p><a href="https://juliamolsim.github.io/Molly.jl/dev/">Redirect</a></p>
+    <p><a href="https://juliamolsim.github.io/Molly.jl/stable/">Redirect</a></p>
   </body>
 </html>


### PR DESCRIPTION
Fix default link for GitHub pages on the Molly github page.