### PR TITLE
Add option to disable loggers in all Simulator structs

### DIFF
--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -619,7 +619,8 @@ function simulate!(sys::ReplicaSystem,
                     n_steps::Integer;
                     assign_velocities::Bool=false,
                     rng=Random.GLOBAL_RNG,
-                    n_threads::Integer=Threads.nthreads())
+                    n_threads::Integer=Threads.nthreads(),
+                    run_loggers = true)
     if sys.n_replicas != length(sim.simulators)
         throw(ArgumentError("number of replicas in ReplicaSystem ($(length(sys.n_replicas))) " *
                 "and simulators in TemperatureREMD ($(length(sim.simulators))) do not match"))
@@ -631,7 +632,7 @@ function simulate!(sys::ReplicaSystem,
         end
     end
 
-    return simulate_remd!(sys, sim, n_steps; rng=rng, n_threads=n_threads)
+    return simulate_remd!(sys, sim, n_steps; rng=rng, n_threads=n_threads, run_loggers)
 end
 
 """
@@ -720,7 +721,8 @@ function simulate!(sys::ReplicaSystem,
                     n_steps::Integer;
                     assign_velocities::Bool=false,
                     rng=Random.GLOBAL_RNG,
-                    n_threads::Integer=Threads.nthreads())
+                    n_threads::Integer=Threads.nthreads(),
+                    run_loggers = true)
     if sys.n_replicas != length(sim.simulators)
         throw(ArgumentError("number of replicas in ReplicaSystem ($(length(sys.n_replicas))) " *
                 "and simulators in HamiltonianREMD ($(length(sim.simulators))) do not match"))
@@ -732,7 +734,7 @@ function simulate!(sys::ReplicaSystem,
         end
     end
     
-    return simulate_remd!(sys, sim, n_steps; rng=rng, n_threads=n_threads)
+    return simulate_remd!(sys, sim, n_steps; rng=rng, n_threads=n_threads, run_loggers)
 end
 
 function remd_exchange!(sys::ReplicaSystem{D, G, T},
@@ -770,7 +772,7 @@ function remd_exchange!(sys::ReplicaSystem{D, G, T},
 end
 
 """
-    simulate_remd!(sys, remd_sim, n_steps; rng=Random.GLOBAL_RNG, n_threads=Threads.nthreads())
+    simulate_remd!(sys, remd_sim, n_steps; rng=Random.GLOBAL_RNG, n_threads=Threads.nthreads(), run_loggers = true)
 
 Run a REMD simulation on a [`ReplicaSystem`](@ref) using a REMD simulator.
 """
@@ -778,7 +780,8 @@ function simulate_remd!(sys::ReplicaSystem,
                         remd_sim,
                         n_steps::Integer;
                         rng=Random.GLOBAL_RNG,
-                        n_threads::Integer=Threads.nthreads())
+                        n_threads::Integer=Threads.nthreads(),
+                        run_loggers = true)
     if sys.n_replicas != length(remd_sim.simulators)
         throw(ArgumentError("number of replicas in ReplicaSystem ($(length(sys.n_replicas))) " *
             "and simulators in the REMD simulator ($(length(remd_sim.simulators))) do not match"))
@@ -808,7 +811,7 @@ function simulate_remd!(sys::ReplicaSystem,
             n_attempts += 1
             m = n + 1
             Δ, exchanged = remd_exchange!(sys, remd_sim, n, m; rng=rng, n_threads=n_threads)
-            if exchanged && !isnothing(sys.exchange_logger)
+            if exchanged && !isnothing(sys.exchange_logger) && run_loggers
                 log_property!(sys.exchange_logger, sys, nothing, cycle * cycle_length;
                                     indices=(n, m), delta=Δ, n_threads=n_threads)
             end
@@ -822,7 +825,7 @@ function simulate_remd!(sys::ReplicaSystem,
         end
     end
 
-    if !isnothing(sys.exchange_logger)
+    if !isnothing(sys.exchange_logger) && run_loggers
         finish_logs!(sys.exchange_logger; n_steps=n_steps, n_attempts=n_attempts)
     end
 

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -118,9 +118,10 @@ struct VelocityVerlet{T, C}
     dt::T
     coupling::C
     remove_CM_motion::Int
+    run_loggers::Bool
 end
 
-function VelocityVerlet(; dt, coupling=NoCoupling(), remove_CM_motion=1)
+function VelocityVerlet(; dt, coupling=NoCoupling(), run_loggers = true, remove_CM_motion=1)
     return VelocityVerlet(dt, coupling, Int(remove_CM_motion))
 end
 
@@ -131,7 +132,7 @@ function simulate!(sys,
     sys.coords = wrap_coords.(sys.coords, (sys.boundary,))
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
-    run_loggers!(sys, neighbors, 0; n_threads=n_threads)
+    sim.run_loggers && run_loggers!(sys, neighbors, 0; n_threads=n_threads)
     accels_t = accelerations(sys, neighbors; n_threads=n_threads)
     accels_t_dt = zero(accels_t)
 
@@ -160,7 +161,7 @@ function simulate!(sys,
             accels_t = accels_t_dt
         end
 
-        run_loggers!(sys, neighbors, step_n; n_threads=n_threads)
+        sim.run_loggers && run_loggers!(sys, neighbors, step_n; n_threads=n_threads)
     end
     return sys
 end

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -820,8 +820,8 @@ end
         trial_args=Dict(:shift_size => 0.1u"nm"),
     )
 
-    @time simulate!(sys, simulator_uniform , n_steps; log_states=true)
-    @time simulate!(sys, simulator_gaussian, n_steps; log_states=true)
+    @time simulate!(sys, simulator_uniform , n_steps)
+    @time simulate!(sys, simulator_gaussian, n_steps)
 
     acceptance_rate = sys.loggers.mcl.n_accept / sys.loggers.mcl.n_trials
     @info "Acceptance Rate: $acceptance_rate"


### PR DESCRIPTION
Thoughts on adding `run_loggers` parameter to all Simulator structs? I noticed it exists in the `StepestDescentMinimizer` but not other things like `VelocityVerlet`.

I ran into a use case where I would like to disable logging for the first 300k steps of a VV scheme and then re-enable it after the system has come to the correct temperature. Could also be worth allowing users to change what gets logged in-between calls to `simulate!` within the same code (maybe you can do this already I dunno). Something like `modify_loggers!(sys, ...)`. I also think there's a lot of performance to be gained here, maybe by writing to a file instead of RAM, just a thought.

I have not gone thru and made all the necessary changes just wanted to open this to discussion.