### PR TITLE
Add caveat to NoseHoover docs

### DIFF
--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -489,7 +489,8 @@ end
     NoseHoover(; <keyword arguments>)
 
 The Nosé-Hoover integrator, a NVT simulator that extends velocity Verlet to control the
-temperature of the system.
+temperature of the system. The current implementation is limited to ergodic systems.
+Future work will implement an improved scheme.
 
 See [Evans and Holian 1985](https://doi.org/10.1063/1.449071).
 


### PR DESCRIPTION
The code I wrote for this integrator is limited to ergodic systems as pointed out this paper:

https://www2.stat.duke.edu/~scs/Projects/REMD/NoseHooverChains1992.pdf

I will update this code at some point to use a new integration scheme as outlined in the paper below. This might be a bit beyond my capabilities in terms of math, but this is the default scheme in LAMMPS for NVT and NPT:

https://iopscience.iop.org/article/10.1088/0305-4470/39/19/S18/pdf