### PR TITLE
Add anisotropic MC barostat

### DIFF
--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -242,7 +242,7 @@ function apply_coupling!(sys::System{D, G, T}, barostat::MonteCarloBarostat, sim
 end
 
 @doc raw"""
-    MonteCarloBarostat(pressure_X, pressure_Y, pressure_Z, temperature, boundary;
+    MonteCarloAnisotropicBarostat(pressure_X, pressure_Y, pressure_Z, temperature, boundary;
                        n_steps=30, n_iterations=1, scale_factor=0.01, scale_increment=1.1,
                        max_volume_frac=0.3, trial_find_neighbors=false)
 
@@ -304,7 +304,7 @@ function MonteCarloAnisotropicBarostat(
     max_volume_frac=0.3,
     trial_find_neighbors=false,
 )
-    pressure = [pressure_X, pressure_Y, pressure_Z]
+    pressure = SVector(pressure_X, pressure_Y, pressure_Z)
     volume_scale = box_volume(boundary) * float_type(boundary)(scale_factor)
     volume_scale = fill(volume_scale, 3)
 

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -273,15 +273,15 @@ It should be used alongside a temperature coupling method such as the [`Langevin
 simulator or [`AndersenThermostat`](@ref) coupling.
 The neighbor list is not updated when making trial moves or after accepted moves.
 Note that the barostat can change the bounding box of the system.
-`pressure` is a SVector of lenght 3 with components pressX, pressY, and pressZ
-representing the target pressure in each axis.
+For 3D systems, `pressure` is a SVector of lenght 3 with components pressX, pressY,
+and pressZ representing the target pressure in each axis.
+For 2D systems, `pressure` is a SVector of lenght 2 with components pressX and pressY.
 To keep an axis fixed, set the corresponding pressure to `nothing`.
-For rectangular boundaries `pressZ` is not required.
 
 Not currently compatible with automatic differentiation using Zygote.
 """
 mutable struct MonteCarloAnisotropicBarostat{D, T, P, K, V}
-  pressure::SVector{D,P}
+    pressure::SVector{D,P}
     temperature::K
     n_steps::Int
     n_iterations::Int

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -6,7 +6,8 @@ export
     AndersenThermostat,
     RescaleThermostat,
     BerendsenThermostat,
-    MonteCarloBarostat
+    MonteCarloBarostat,
+    MonteCarloAnisotropicBarostat
 
 """
     apply_coupling!(system, coupling, simulator, neighbors=nothing,
@@ -234,6 +235,190 @@ function apply_coupling!(sys::System{D, G, T}, barostat::MonteCarloBarostat, sim
                                             V * barostat.max_volume_frac)
                 barostat.n_attempted = 0
                 barostat.n_accepted = 0
+            end
+        end
+    end
+    return recompute_forces
+end
+
+@doc raw"""
+    MonteCarloBarostat(pressure_X, pressure_Y, pressure_Z, temperature, boundary;
+                       n_steps=30, n_iterations=1, scale_factor=0.01, scale_increment=1.1,
+                       max_volume_frac=0.3, trial_find_neighbors=false)
+
+The Monte Carlo anisotropic barostat for controlling pressure.
+
+See [Chow and Ferguson 1995](https://doi.org/10.1016/0010-4655(95)00059-O),
+[Åqvist et al. 2004](https://doi.org/10.1016/j.cplett.2003.12.039) and the OpenMM
+source code.
+At regular intervals a Monte Carlo step is attempted by scaling the coordinates and
+the bounding box by a randomly chosen amount in a randomly selected axis.
+The step is accepted or rejected based on
+```math
+\Delta W = \Delta E + P \Delta V - N k_B T \ln \left( \frac{V + \Delta V}{V} \right)
+```
+where `ΔE` is the change in potential energy, `P` is the equilibrium pressure along the
+selected axis, `ΔV` is the change in volume, `N` is the number of molecules in the system,
+`T` is the equilibrium temperature and `V` is the system volume.
+If `ΔW ≤ 0` the step is always accepted, if `ΔW > 0` the step is accepted with probability
+`exp(-ΔW/kT)`.
+
+The scale factor is modified over time to maintain an acceptance rate of around half.
+If the topology of the system is set then molecules are moved as a unit so properties
+such as bond lengths do not change.
+
+The barostat assumes that the simulation is being run at a constant temperature but
+does not actively control the temperature.
+It should be used alongside a temperature coupling method such as the [`Langevin`](@ref)
+simulator or [`AndersenThermostat`](@ref) coupling.
+The neighbor list is not updated when making trial moves or after accepted moves.
+Note that the barostat can change the bounding box of the system.
+To keep an axis fixed, set the corresponding pressure to `nothing`.
+For rectangular boundaries `pressure_Z` is not required.
+
+Not currently compatible with automatic differentiation using Zygote.
+"""
+mutable struct MonteCarloAnisotropicBarostat{T, P, K, V}
+    pressure::P
+    temperature::K
+    n_steps::Int
+    n_iterations::Int
+    volume_scale::V
+    scale_increment::T
+    max_volume_frac::T
+    trial_find_neighbors::Bool
+    n_attempted::Vector{Int}
+    n_accepted::Vector{Int}
+end
+
+function MonteCarloAnisotropicBarostat(
+    pressure_X,
+    pressure_Y,
+    pressure_Z,
+    temperature,
+    boundary;
+    n_steps=30,
+    n_iterations=1,
+    scale_factor=0.01,
+    scale_increment=1.1,
+    max_volume_frac=0.3,
+    trial_find_neighbors=false,
+)
+    pressure = [pressure_X, pressure_Y, pressure_Z]
+    volume_scale = box_volume(boundary) * float_type(boundary)(scale_factor)
+    volume_scale = fill(volume_scale, 3)
+
+    return MonteCarloAnisotropicBarostat(
+        pressure,
+        temperature,
+        n_steps,
+        n_iterations,
+        volume_scale,
+        scale_increment,
+        max_volume_frac,
+        trial_find_neighbors,
+        fill(0, 3),
+        fill(0, 3),
+    )
+end
+
+function MonteCarloAnisotropicBarostat(
+    pressure_X,
+    pressure_Y,
+    temperature,
+    boundary::RectangularBoundary;
+    n_steps=30,
+    n_iterations=1,
+    scale_factor=0.01,
+    scale_increment=1.1,
+    max_volume_frac=0.3,
+    trial_find_neighbors=false,
+)
+    pressure = SVector(pressure_X, pressure_Y)
+    volume_scale = box_volume(boundary) * float_type(boundary)(scale_factor)
+    volume_scale = fill(volume_scale, 2)
+
+    return MonteCarloAnisotropicBarostat(
+        pressure,
+        temperature,
+        n_steps,
+        n_iterations,
+        volume_scale,
+        scale_increment,
+        max_volume_frac,
+        trial_find_neighbors,
+        fill(0, 2),
+        fill(0, 2),
+    )
+end
+
+function apply_coupling!(
+    sys::System{D, G, T},
+    barostat::MonteCarloAnisotropicBarostat,
+    sim,
+    neighbors=nothing,
+    step_n::Integer=0;
+    n_threads::Integer=Threads.nthreads()
+) where {D, G, T}
+
+    !iszero(step_n % barostat.n_steps) && return false
+    all(isnothing, barostat.pressure) && return false
+
+    kT = sys.k * barostat.temperature
+    n_molecules = isnothing(sys.topology) ? length(sys) : length(sys.topology.molecule_atom_counts)
+    recompute_forces = false
+
+    axis = undef
+    while true
+        axis = rand(1:D)
+        !isnothing(barostat.pressure[axis]) && break
+    end
+    mask1 = falses(D)
+    mask2 = trues(D)
+    mask1[axis] = true
+    mask2[axis] = false
+
+    for attempt_n in 1:barostat.n_iterations
+        E = potential_energy(sys, neighbors; n_threads=n_threads)
+        V = box_volume(sys.boundary)
+        dV = barostat.volume_scale[axis] * (2 * rand(T) - 1)
+        v_scale = (V + dV) / V
+        l_scale = SVector{D}(mask1 * (D == 2 ? sqrt(v_scale) : cbrt(v_scale)) + mask2)
+        old_coords = copy(sys.coords)
+        old_boundary = sys.boundary
+        scale_coords!(sys, l_scale)
+
+        if barostat.trial_find_neighbors
+            neighbors_trial = find_neighbors(sys, sys.neighbor_finder, neighbors, step_n, true;
+                                             n_threads=n_threads)
+        else
+            # Assume neighbors are unchanged by the change in coordinates
+            # This may not be valid for larger changes
+            neighbors_trial = neighbors
+        end
+        E_trial = potential_energy(sys, neighbors_trial; n_threads=n_threads)
+        dE = energy_remove_mol(E_trial - E)
+        dW = dE + uconvert(unit(dE), barostat.pressure[axis] * dV) - n_molecules * kT * log(v_scale)
+        if dW <= zero(dW) || rand(T) < exp(-dW / kT)
+            recompute_forces = true
+            barostat.n_accepted[axis] += 1
+        else
+            sys.coords = old_coords
+            sys.boundary = old_boundary
+        end
+        barostat.n_attempted[axis] += 1
+
+        # Modify size of volume change to keep accept/reject ratio roughly equal
+        if barostat.n_attempted[axis] >= 10
+          if barostat.n_accepted[axis] < 0.25 * barostat.n_attempted[axis]
+            barostat.volume_scale[axis] /= barostat.scale_increment
+                barostat.n_attempted[axis] = 0
+                barostat.n_accepted[axis] = 0
+              elseif barostat.n_accepted[axis] > 0.75 * barostat.n_attempted[axis]
+                barostat.volume_scale[axis] = min(barostat.volume_scale[axis] * barostat.scale_increment,
+                                            V * barostat.max_volume_frac)
+                barostat.n_attempted[axis] = 0
+                barostat.n_accepted[axis] = 0
             end
         end
     end

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -759,7 +759,9 @@ Not currently compatible with automatic differentiation using Zygote.
 function scale_coords!(sys, scale_factor; ignore_molecules=false)
     if ignore_molecules || isnothing(sys.topology)
         sys.boundary = scale_boundary(sys.boundary, scale_factor)
-        sys.coords = sys.coords .* scale_factor
+        for i in eachindex(sys.coords)
+            sys.coords[i] = sys.coords[i] .* scale_factor
+        end
     elseif sys.boundary isa TriclinicBoundary
         error("scaling coordinates by molecule is not compatible with a TriclinicBoundary")
     else

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -966,9 +966,7 @@ end
     pressure_test_set = (
         SVector(1.0u"bar", 1.0u"bar", 1.0u"bar"), # XYZ-axes coupled with the same pressure value
         SVector(1.5u"bar", 0.5u"bar", 1.0u"bar"), # XYZ-axes coupled with different pressure values
-        SVector(1.0u"bar", nothing, nothing), # Only X-axis coupled
         SVector(nothing, 1.0u"bar", nothing), # Only Y-axis coupled
-        SVector(nothing, nothing, 1.0u"bar"), # Only Z-axis coupled
         SVector(nothing, nothing, nothing), # Uncoupled
     )
     

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -949,9 +949,7 @@ end
     atom_mass = 39.947u"u"
     boundary = CubicBoundary(8.0u"nm")
     temp = 288.15u"K"
-    press_x = 1.0u"bar"
-    press_y = 1.0u"bar"
-    press_z = 1.0u"bar"
+    press = SVector(1.0u"bar", 1.0u"bar", 1.0u"bar")
     dt = 0.0005u"ps"
     friction = 1.0u"ps^-1"
     lang = Langevin(dt=dt, temperature=temp, friction=friction)
@@ -991,7 +989,7 @@ end
     @test all(values(sys.loggers.box_volume) .== 512.0u"nm^3")
     @test sys.boundary == CubicBoundary(8.0u"nm")
     
-    barostat = MonteCarloAnisotropicBarostat(press_x, press_y, press_z, temp, boundary)
+    barostat = MonteCarloAnisotropicBarostat(press, temp, boundary)
     lang_baro = Langevin(dt=dt, temperature=temp, friction=friction, coupling=barostat)
     vvand_baro = VelocityVerlet(dt=dt, coupling=(AndersenThermostat(temp, 1.0u"ps"), barostat))
 

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -1002,7 +1002,7 @@ end
             end
             AT = gpu ? CuArray : Array
 
-            global sys = System(
+            sys = System(
                 atoms=AT(atoms),
                 coords=AT(coords),
                 boundary=boundary,

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -1009,8 +1009,8 @@ end
                 @test mean(values(sys.loggers.potential_energy)) < 0.0u"kJ * mol^-1"
                 all(!isnothing, press) && @test 0.7u"bar" < mean(values(sys.loggers.pressure)) < 1.3u"bar"
                 any(!isnothing, press) && @test 0.1u"bar" < std(values(sys.loggers.pressure)) < 0.5u"bar"
-                any(!isnothing, press) && @test 800.0u"nm^3" < mean(values(sys.loggers.box_volume)) < 1200u"nm^3"
-                any(!isnothing, press) && @test 80.0u"nm^3" < std(values(sys.loggers.box_volume)) < 150.0u"nm^3"
+                any(!isnothing, press) && @test 800.0u"nm^3" < mean(values(sys.loggers.box_volume)) < 1300u"nm^3"
+                any(!isnothing, press) && @test 80.0u"nm^3" < std(values(sys.loggers.box_volume)) < 300.0u"nm^3"
                 axis_is_uncoupled = isnothing.(press)
                 axis_is_unchanged = sys.boundary .== 8.0u"nm"
                 @test all(axis_is_uncoupled .== axis_is_unchanged)

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -942,6 +942,99 @@ end
     end
 end
 
+@testset "Monte Carlo anisotropic barostat" begin
+    # See http://www.sklogwiki.org/SklogWiki/index.php/Argon for parameters
+    n_atoms = 25
+    n_steps = 1_000_000
+    atom_mass = 39.947u"u"
+    boundary = CubicBoundary(8.0u"nm")
+    temp = 288.15u"K"
+    press_x = 1.0u"bar"
+    press_y = 1.0u"bar"
+    press_z = 1.0u"bar"
+    dt = 0.0005u"ps"
+    friction = 1.0u"ps^-1"
+    lang = Langevin(dt=dt, temperature=temp, friction=friction)
+    atoms = fill(Atom(mass=atom_mass, σ=0.3345u"nm", ϵ=1.0451u"kJ * mol^-1"), n_atoms)
+    coords = place_atoms(n_atoms, boundary; min_dist=1.0u"nm")
+    n_log_steps = 500
+    
+    box_volume_wrapper(sys, neighbors; kwargs...) = box_volume(sys.boundary)
+    VolumeLogger(n_steps) = GeneralObservableLogger(box_volume_wrapper, typeof(1.0u"nm^3"), n_steps)
+    
+    sys = System(
+        atoms=atoms,
+        coords=coords,
+        boundary=boundary,
+        pairwise_inters=(LennardJones(),),
+        loggers=(
+            temperature=TemperatureLogger(n_log_steps),
+            total_energy=TotalEnergyLogger(n_log_steps),
+            kinetic_energy=KineticEnergyLogger(n_log_steps),
+            potential_energy=PotentialEnergyLogger(n_log_steps),
+            virial=VirialLogger(n_log_steps),
+            pressure=PressureLogger(n_log_steps),
+            box_volume=VolumeLogger(n_log_steps),
+        ),
+    )
+    
+    simulate!(deepcopy(sys), lang, 1_000; n_threads=1)
+    @time simulate!(sys, lang, n_steps; n_threads=1)
+    
+    @test 280.0u"K" < mean(values(sys.loggers.temperature)) < 300.0u"K"
+    @test 50.0u"kJ * mol^-1" < mean(values(sys.loggers.total_energy  )) < 120.0u"kJ * mol^-1"
+    @test 50.0u"kJ * mol^-1" < mean(values(sys.loggers.kinetic_energy)) < 120.0u"kJ * mol^-1"
+    @test mean(values(sys.loggers.potential_energy)) < 0.0u"kJ * mol^-1"
+    @test -5.0u"kJ * mol^-1" < mean(values(sys.loggers.virial)) < 5.0u"kJ * mol^-1"
+    @test 1.7u"bar" < mean(values(sys.loggers.pressure)) < 2.2u"bar"
+    @test 0.1u"bar" < std( values(sys.loggers.pressure)) < 0.5u"bar"
+    @test all(values(sys.loggers.box_volume) .== 512.0u"nm^3")
+    @test sys.boundary == CubicBoundary(8.0u"nm")
+    
+    barostat = MonteCarloAnisotropicBarostat(press_x, press_y, press_z, temp, boundary)
+    lang_baro = Langevin(dt=dt, temperature=temp, friction=friction, coupling=barostat)
+    vvand_baro = VelocityVerlet(dt=dt, coupling=(AndersenThermostat(temp, 1.0u"ps"), barostat))
+
+    for sim in (lang_baro, vvand_baro)
+        for gpu in gpu_list
+            if gpu && sim == vvand_baro
+                continue
+            end
+            AT = gpu ? CuArray : Array
+
+            global sys = System(
+                atoms=AT(atoms),
+                coords=AT(coords),
+                boundary=boundary,
+                pairwise_inters=(LennardJones(),),
+                loggers=(
+                    temperature=TemperatureLogger(n_log_steps),
+                    total_energy=TotalEnergyLogger(n_log_steps),
+                    kinetic_energy=KineticEnergyLogger(n_log_steps),
+                    potential_energy=PotentialEnergyLogger(n_log_steps),
+                    virial=VirialLogger(n_log_steps),
+                    pressure=PressureLogger(n_log_steps),
+                    box_volume=VolumeLogger(n_log_steps),
+                ),
+            )
+
+            simulate!(deepcopy(sys), sim, 1_000; n_threads=1)
+            @time simulate!(sys, sim, n_steps; n_threads=1)
+
+            @test 260.0u"K" < mean(values(sys.loggers.temperature)) < 300.0u"K"
+            @test 50.0u"kJ * mol^-1" < mean(values(sys.loggers.total_energy)) < 120.0u"kJ * mol^-1"
+            @test 50.0u"kJ * mol^-1" < mean(values(sys.loggers.kinetic_energy)) < 120.0u"kJ * mol^-1"
+            @test mean(values(sys.loggers.potential_energy)) < 0.0u"kJ * mol^-1"
+            @test -5.0u"kJ * mol^-1" < mean(values(sys.loggers.virial)) < 5.0u"kJ * mol^-1"
+            @test 0.8u"bar" < mean(values(sys.loggers.pressure)) < 1.2u"bar"
+            @test 0.1u"bar" < std(values(sys.loggers.pressure)) < 0.5u"bar"
+            @test 900.0u"nm^3" < mean(values(sys.loggers.box_volume)) < 1100u"nm^3"
+            @test 80.0u"nm^3" < std(values(sys.loggers.box_volume)) < 120.0u"nm^3"
+            @test sys.boundary != CubicBoundary(8.0u"nm")
+        end
+    end
+end
+
 @testset "Crystals" begin
     r_cut = 8.5u"Å"
     a = 5.2468u"Å"


### PR DESCRIPTION
This PR adds an implementation for the anisotropic Monte Carlo barostat following OpenMM's implementation.

The new interface for using this barostat in 3D and 2D systems is:

```julia
MonteCarloAnisotropicBarostat(
    1.0u"bar", # Pressure in the X-axis
    1.0u"bar", # Pressure in the Y-axis
    1.0u"bar", # Pressure in the Z-axis
    temperature,
    boundary
)
```
and
```julia
MonteCarloAnisotropicBarostat(
    1.0u"bar*nm", # Pressure in the X-axis
    1.0u"bar*nm", # Pressure in the Y-axis
    temperature,
    boundary
)

```
respectively.

If you set any pressure value as 'nothing', the barostat is uncoupled in that axis. For example, for coupling only the Y-axis, you could do the following:

```julia
MonteCarloAnisotropicBarostat(
    nothing, # Keep the box in the X-axis fixed
    1.0u"bar", # Scale box in the Y-axis
    nothing, # Keep the box in the Z-axis fixed
    temperature,
    boundary
)
```

After discussing and merging this PR, I will start working on the constant surface tension MC barostat for membrane simulations.