### PR TITLE
implement MC membrane barostat

### DIFF
--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -7,7 +7,8 @@ export
     RescaleThermostat,
     BerendsenThermostat,
     MonteCarloBarostat,
-    MonteCarloAnisotropicBarostat
+    MonteCarloAnisotropicBarostat,
+    MonteCarloMembraneBarostat
 
 """
     apply_coupling!(system, coupling, simulator, neighbors=nothing,
@@ -386,6 +387,192 @@ function apply_coupling!(sys::System{D, G, T},
             elseif barostat.n_accepted[axis] > 0.75 * barostat.n_attempted[axis]
                 barostat.volume_scale[axis] = min(barostat.volume_scale[axis] * barostat.scale_increment,
                                                   V * barostat.max_volume_frac)
+                barostat.n_attempted[axis] = 0
+                barostat.n_accepted[axis] = 0
+            end
+        end
+    end
+    return recompute_forces
+end
+
+@doc raw"""
+    MonteCarloMembraneBarostat(pressure, temperature, boundary; n_steps=30,
+                       n_iterations=1, scale_factor=0.01, scale_increment=1.1,
+                       max_volume_frac=0.3, trial_find_neighbors=false)
+
+The Monte Carlo membrane barostat for controlling pressure.
+
+See [Chow and Ferguson 1995](https://doi.org/10.1016/0010-4655(95)00059-O),
+[Åqvist et al. 2004](https://doi.org/10.1016/j.cplett.2003.12.039) and the OpenMM
+source code.
+At regular intervals a Monte Carlo step is attempted by scaling the coordinates and
+the bounding box by a randomly chosen amount in a randomly selected axis.
+The step is accepted or rejected based on
+```math
+\Delta W = \Delta E + P \Delta V - \gamma \Delta A - N k_B T \ln \left( \frac{V + \Delta V}{V} \right)
+```
+where `ΔE` is the change in potential energy, `P` is the equilibrium pressure along the
+selected axis, `ΔV` is the change in volume, `γ` is the surface tension, `ΔA` is the change
+in surface area, `N` is the number of molecules in the system, `T` is the equilibrium
+temperature and `V` is the system volume.
+If `ΔW ≤ 0` the step is always accepted, if `ΔW > 0` the step is accepted with probability
+`exp(-ΔW/kT)`.
+
+The scale factor is modified over time to maintain an acceptance rate of around half.
+If the topology of the system is set then molecules are moved as a unit so properties
+such as bond lengths do not change.
+
+The barostat assumes that the simulation is being run at a constant temperature but
+does not actively control the temperature.
+It should be used alongside a temperature coupling method such as the [`Langevin`](@ref)
+simulator or [`AndersenThermostat`](@ref) coupling.
+The neighbor list is not updated when making trial moves or after accepted moves.
+Note that the barostat can change the bounding box of the system.
+This barostat is only available for 3D systems.
+
+Not currently compatible with automatic differentiation using Zygote.
+"""
+mutable struct MonteCarloMembraneBarostat{T, P, K, V, S}
+    pressure::SVector{3,P}
+    tension::S
+    temperature::K
+    n_steps::Int
+    n_iterations::Int
+    volume_scale::V
+    scale_increment::T
+    max_volume_frac::T
+    trial_find_neighbors::Bool
+    n_attempted::Vector{Int}
+    n_accepted::Vector{Int}
+    xy_isotropy::Bool
+    constant_volume::Bool
+end
+
+function MonteCarloMembraneBarostat(
+    pressure,
+    tension,
+    temperature,
+    boundary;
+    n_steps=30,
+    n_iterations=1,
+    scale_factor=0.01,
+    scale_increment=1.1,
+    max_volume_frac=0.3,
+    trial_find_neighbors=false,
+    xy_isotropy=false,
+    z_axis_fixed=false,
+    constant_volume=false,
+)
+    volume_scale_factor = box_volume(boundary) * float_type(boundary)(scale_factor)
+    volume_scale = fill(volume_scale_factor, 3)
+
+    length(boundary.side_lengths) != 3 && throw(ArgumentError("boundary dimensionality " *
+        "($(length(boundary.side_lengths))) must be 3"))
+    z_axis_fixed && constant_volume && throw(ArgumentError("cannot keep z-axis fixed " *
+        "while making the volume constant"))
+
+    pressX = pressure
+    pressY = pressure
+    pressZ = (z_axis_fixed || constant_volume) ? nothing : pressure
+
+    return MonteCarloMembraneBarostat(
+        SVector(pressX, pressY, pressZ),
+        tension,
+        temperature,
+        n_steps,
+        n_iterations,
+        volume_scale,
+        scale_increment,
+        max_volume_frac,
+        trial_find_neighbors,
+        fill(0, 3),
+        fill(0, 3),
+        xy_isotropy,
+        constant_volume,
+    )
+end
+
+function apply_coupling!(
+    sys::System{D, G, T},
+    barostat::MonteCarloMembraneBarostat,
+    sim,
+    neighbors=nothing,
+    step_n::Integer=0;
+    n_threads::Integer=Threads.nthreads()
+) where {D, G, T}
+
+    !iszero(step_n % barostat.n_steps) && return false
+
+    kT = sys.k * barostat.temperature
+    n_molecules = isnothing(sys.topology) ? length(sys) : length(sys.topology.molecule_atom_counts)
+    recompute_forces = false
+
+    for attempt_n in 1:barostat.n_iterations
+        axis = 0
+        while true
+            axis = rand(1:D)
+            !isnothing(barostat.pressure[axis]) && break
+        end
+
+        E = potential_energy(sys, neighbors; n_threads=n_threads)
+        V = box_volume(sys.boundary)
+        dV = barostat.volume_scale[axis] * (2 * rand(T) - 1)
+        v_scale = (V + dV) / V
+        l_scale = SVector{D,T}(1.0, 1.0, 1.0)
+        if (axis == 1 || axis == 2) && barostat.xy_isotropy
+            xy_scale = sqrt(v_scale)
+            l_scale = SVector{D}(xy_scale, xy_scale, T(1.0))
+        else
+            mask1 = falses(D)
+            mask2 = trues(D)
+            mask1[axis] = true
+            mask2[axis] = false
+            l_scale = SVector{D}(mask1 * v_scale + mask2)
+        end
+
+        if barostat.constant_volume
+            l_scale = SVector{D}(l_scale[1], l_scale[2], inv(l_scale[1]*l_scale[2]))
+            v_scale = T(1.0)
+            dV = zero(dV)
+        end
+
+        dA = sys.boundary[1]*sys.boundary[2] * (l_scale[1]*l_scale[2] - T(1.0))
+
+        old_coords = copy(sys.coords)
+        old_boundary = sys.boundary
+        scale_coords!(sys, l_scale)
+
+        if barostat.trial_find_neighbors
+            neighbors_trial = find_neighbors(sys, sys.neighbor_finder, neighbors, step_n, true;
+                                             n_threads=n_threads)
+        else
+            # Assume neighbors are unchanged by the change in coordinates
+            # This may not be valid for larger changes
+            neighbors_trial = neighbors
+        end
+        E_trial = potential_energy(sys, neighbors_trial; n_threads=n_threads)
+        dE = energy_remove_mol(E_trial - E)
+        PdV = uconvert(unit(dE), barostat.pressure[axis] * dV)
+        γdA = uconvert(unit(dE), barostat.tension * dA)
+        dW = dE + PdV - γdA - n_molecules * kT * log(v_scale)
+        if dW <= zero(dW) || rand(T) < exp(-dW / kT)
+            recompute_forces = true
+            barostat.n_accepted[axis] += 1
+        else
+            sys.coords = old_coords
+            sys.boundary = old_boundary
+        end
+        barostat.n_attempted[axis] += 1
+
+        # Modify size of volume change to keep accept/reject ratio roughly equal
+        if barostat.n_attempted[axis] >= 10
+          if barostat.n_accepted[axis] < 0.25 * barostat.n_attempted[axis]
+            barostat.volume_scale[axis] /= barostat.scale_increment
+                barostat.n_attempted[axis] = 0
+                barostat.n_accepted[axis] = 0
+              elseif barostat.n_accepted[axis] > 0.75 * barostat.n_attempted[axis]
+                barostat.volume_scale[axis] = min(barostat.volume_scale[axis] * barostat.scale_increment,
+                                            V * barostat.max_volume_frac)
                 barostat.n_attempted[axis] = 0
                 barostat.n_accepted[axis] = 0
             end


### PR DESCRIPTION
This PR adds an implementation for the Monte Carlo membrane barostat following OpenMM's implementation.

This barostat is only available for 3D systems, and the API is as follows:

```julia
MonteCarloMembraneBarostat(
    1.0u"bar",       # Pressure in the system
    1.0u"bar*nm" # Surface tension
    temperature,
    boundary;
    xy_isotropy=false,              # If true, scale the XY-axes isotropically
    constant_volume=false,    # If true, keep the volume constant by scaling the Z-axis accordingly
    z_axis_fixed=false             # If true, keep the Z-axis fixed
)
and
```

In this barostat, `constant_volume` and `z_axis_fixed` cannot be true simultaneously.