### PR TITLE
fix MC membrane barostat scaling factor adjustment

### DIFF
--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -520,6 +520,7 @@ function apply_coupling!(
             axis = rand(1:D)
             !isnothing(barostat.pressure[axis]) && break
         end
+        axis = barostat.xy_isotropy && axis == 2 ? 1 : axis
 
         E = potential_energy(sys, neighbors; n_threads=n_threads)
         V = box_volume(sys.boundary)


### PR DESCRIPTION
The MC barostat adjusts the scaling in each axis depending on the trials. In the case of the membrane barostat, when the X and Y axes are coupled isotropically, the scaling adjustment should be performed in both axes. An alternative approach is to always select the X-axis when scaling in the XY plane (as OpenMM does). This PR implements that approach:

```julia
axis = barostat.xy_isotropy && axis == 2 ? 1 : axis
```