### PR TITLE
Fix creation of Molly.System from AtomsBase structures

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1124,8 +1124,14 @@ function System(sys::AbstractSystem{D}, energy_units, force_units) where D
         atoms_data[i] = AtomData(element=String(atomic_symbol(atom)))
     end
 
-    coords = position(sys)
-    vels = velocity(sys)
+    # AtomsBase does not specify type for coordinates or velocities
+    # so it is best to use unified type. Thus conversion to SVector.
+    coords = map(position(sys)) do r
+        SVector(r...)
+    end
+    vels = map(velocity(sys)) do v
+        SVector(v...)
+    end
 
     mass_dim = dimension(atomic_mass(sys, 1))
     if mass_dim == u"𝐌" && dimension(energy_units) == u"𝐋^2 * 𝐌 * 𝐍^-1 * 𝐓^-2"

--- a/src/units.jl
+++ b/src/units.jl
@@ -143,7 +143,7 @@ function validate_coords(coords)
     end
 
     valid_length_dimensions = [u"𝐋", NoDims]
-    coord_dimension = dimension(zero(eltype(coords))[1])
+    coord_dimension = (dimension ∘ eltype ∘ eltype)(coords)
 
     if coord_dimension ∉ valid_length_dimensions
         throw(ArgumentError("coordinate units have dimension $coord_dimension. Length units " *
@@ -163,7 +163,7 @@ function validate_velocities(velocities)
     end
 
     valid_velocity_dimensions = [u"𝐋 * 𝐓^-1", NoDims]
-    velocity_dimension = dimension(zero(eltype(velocities))[1])
+    velocity_dimension = (dimension ∘ eltype ∘ eltype)(velocities)
 
     if velocity_dimension ∉ valid_velocity_dimensions
         throw(ArgumentError("velocity units have dimension $velocity_dimension. Velocity units " *


### PR DESCRIPTION
AtomsBase does not define what types to use for position and velocity. This can cause some problems, e.g., ExtXYZ data format causes these. To fix this, you need to convert to defined data structure (`SVector` here).

Also, some checks to coordinates and velocities caused some errors. So, I updated those as well.


There are still some potential issues, like what to do, if velocities are missing. I can add a fix for this too, or do you want to do that in some other PR?