### PR TITLE
Nonbonded kernel

### DIFF
--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -2,14 +2,14 @@
 const WARPSIZE = UInt32(32)
 
 macro shfl_multiple_sync(mask, target, width, vars...)
-    all_lines = map(vars) do v
-        Expr(:(=), v,
-            Expr(:call, :shfl_sync,
-                mask, v, target, width
-            )
-        )
-    end
-    return esc(Expr(:block, all_lines...))
+	all_lines = map(vars) do v
+		Expr(:(=), v,
+			Expr(:call, :shfl_sync,
+				mask, v, target, width
+			)
+		)
+	end
+	return esc(Expr(:block, all_lines...))
 end
 
 CUDA.shfl_recurse(op, x::Quantity) = op(x.val) * unit(x)
@@ -18,57 +18,55 @@ CUDA.shfl_recurse(op, x::SVector{2, C}) where C = SVector{2, C}(op(x[1]), op(x[2
 CUDA.shfl_recurse(op, x::SVector{3, C}) where C = SVector{3, C}(op(x[1]), op(x[2]), op(x[3]))
 
 function cuda_threads_blocks_pairwise(n_neighbors)
-    n_threads_gpu = min(n_neighbors, parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512")))
-    n_blocks = cld(n_neighbors, n_threads_gpu)
-    return n_threads_gpu, n_blocks
+	n_threads_gpu = min(n_neighbors, parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512")))
+	n_blocks = cld(n_neighbors, n_threads_gpu)
+	return n_threads_gpu, n_blocks
 end
 
 function cuda_threads_blocks_specific(n_inters)
-    n_threads_gpu = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_SPECIFIC", "128"))
-    n_blocks = cld(n_inters, n_threads_gpu)
-    return n_threads_gpu, n_blocks
+	n_threads_gpu = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_SPECIFIC", "128"))
+	n_blocks = cld(n_inters, n_threads_gpu)
+	return n_threads_gpu, n_blocks
 end
 
 function pairwise_force_gpu!(buffers, sys::System{D, true, T}, pairwise_inters, nbs, step_n) where {D, T}
-    if typeof(nbs) == NoNeighborList
-        kernel = @cuda launch=false pairwise_force_kernel_nonl!(
-			    buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n,
-                Val(D), Val(sys.force_units))
-        conf = launch_configuration(kernel.fun)
-        threads_basic = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512"))
-        nthreads = min(length(sys.atoms), threads_basic, conf.threads)
-        nthreads = cld(nthreads, WARPSIZE) * WARPSIZE
-        n_blocks_i = cld(length(sys.atoms), WARPSIZE)
-        n_blocks_j = cld(length(sys.atoms), nthreads)
-        kernel(buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n, Val(D),
-               Val(sys.force_units); threads=nthreads, blocks=(n_blocks_i, n_blocks_j))
+	if typeof(nbs) == NoNeighborList
+		kernel = @cuda launch=false pairwise_force_kernel_nonl!(
+				buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n,
+				Val(D), Val(sys.force_units))
+		conf = launch_configuration(kernel.fun)
+		threads_basic = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512"))
+		nthreads = min(length(sys.atoms), threads_basic, conf.threads)
+		nthreads = cld(nthreads, WARPSIZE) * WARPSIZE
+		n_blocks_i = cld(length(sys.atoms), WARPSIZE)
+		n_blocks_j = cld(length(sys.atoms), nthreads)
+		kernel(buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n, Val(D),
+			   Val(sys.force_units); threads=nthreads, blocks=(n_blocks_i, n_blocks_j))
 	else    
 		N = length(sys.coords)
 		n_blocks = cld(N, WARPSIZE)
 		r_cut = sys.neighbor_finder.dist_cutoff
 		if step_n % sys.neighbor_finder.n_steps_reorder == 0 || !sys.neighbor_finder.initialized
-            Morton_bits = 4
-            w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
-            Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
+			Morton_bits = 4
+			w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
+			Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
 			copyto!(buffers.Morton_seq, Morton_seq_cpu)
-            CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary)
-            buffers = ForcesBuffer(buffers.fs_mat, buffers.box_mins, buffers.box_maxs, buffers.Morton_seq)
+			CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary)
 			sys.neighbor_finder.initialized = true
-        end
+		end
 		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true force_kernel!(buffers.Morton_seq, buffers.fs_mat, 
 			buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.force_units), pairwise_inters, 
 			sys.boundary, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, Val(T), Val(D))
 	end
-    return buffers
+	return buffers
 end
 
 
 function pairwise_pe_gpu!(pe_vec_nounits, buffers, sys::System{D, true, T}, pairwise_inters, nbs, step_n) where {D, T}
 	if typeof(nbs) == NoNeighborList
 		n_threads_gpu, n_blocks = cuda_threads_blocks_pairwise(length(nbs))
-    	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks pairwise_pe_kernel!(
-                pe_vec_nounits, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, nbs,
-                step_n, Val(sys.energy_units))
+		CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks pairwise_pe_kernel!(
+			pe_vec_nounits, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, nbs, step_n, Val(sys.energy_units))
 	else
 		N = length(sys.coords)
 		n_blocks = cld(N, WARPSIZE)
@@ -78,7 +76,6 @@ function pairwise_pe_gpu!(pe_vec_nounits, buffers, sys::System{D, true, T}, pair
 		Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
 		copyto!(buffers.Morton_seq, Morton_seq_cpu)
 		CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary)
-		buffers = ForcesBuffer(buffers.fs_mat, buffers.box_mins, buffers.box_maxs, buffers.Morton_seq)
 		sys.neighbor_finder.initialized = true
 		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true energy_kernel!(buffers.Morton_seq, 
 			pe_vec_nounits, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.energy_units), 
@@ -91,12 +88,12 @@ end
 function sorted_Morton_seq(positions, w, bits::Int)
 	N = length(positions)
 	Morton_sequence = Vector{Int32}(undef, N)
-    for i in 1:N
+	for i in 1:N
 		x, y, z = positions[i][1], positions[i][2], positions[i][3]
-        Morton_sequence[i] = Morton_code(floor(Int32, x/w), floor(Int32, y/w), floor(Int32, z/w), bits)
-    end
+		Morton_sequence[i] = Morton_code(floor(Int32, x/w), floor(Int32, y/w), floor(Int32, z/w), bits)
+	end
 	sort = Int32.(sortperm(Morton_sequence))
-    return sort
+	return sort
 end
 
 
@@ -114,13 +111,13 @@ end
 
 # Function to compute Morton code (Z-order) from voxel indices (i, j, k)
 function Morton_code(i::Int32, j::Int32, k::Int32, bits::Int)
-    code = 0
-    for bit in 0:(bits-1)
-        code |= ((i >> bit) & 1) << (3 * bit)
-        code |= ((j >> bit) & 1) << (3 * bit + 1)
-        code |= ((k >> bit) & 1) << (3 * bit + 2)
-    end
-    return Int32(code)
+	code = 0
+	for bit in 0:(bits-1)
+		code |= ((i >> bit) & 1) << (3 * bit)
+		code |= ((j >> bit) & 1) << (3 * bit + 1)
+		code |= ((k >> bit) & 1) << (3 * bit + 2)
+	end
+	return Int32(code)
 end
 
 
@@ -136,8 +133,8 @@ function kernel_min_max!(
 	a = Int32(1)
 	b = Int32(3)
 	r = Int32(n % D32)
-    i = threadIdx().x + (blockIdx().x - a) * blockDim().x
-    local_i = threadIdx().x
+	i = threadIdx().x + (blockIdx().x - a) * blockDim().x
+	local_i = threadIdx().x
 	mins_smem = CuStaticSharedArray(D, (D32, b))
 	maxs_smem = CuStaticSharedArray(D, (D32, b))
 	r_smem = CuStaticSharedArray(D, (r, b))
@@ -154,7 +151,7 @@ function kernel_min_max!(
 		end
 	end
 	
-    sync_threads() 
+	sync_threads() 
 	if i <= n - r && local_i <= D32
 		for k in a:Int32(log2(D32))
 			for xyz in a:b
@@ -224,32 +221,32 @@ forces for the entire row in `WARPSIZE` steps. This is done such that some data 
 subsequent iteration of the force calculation in a row. If `a, b, ...` are different atoms and `1, 2, ...` are order in which each thread calculates
 the interatomic forces, then we can represent this scenario as (considering `WARPSIZE=8`):
 ```
-    × | i j k l m n o p
-    --------------------
-    a | 1 2 3 4 5 6 7 8
-    b | 8 1 2 3 4 5 6 7
-    c | 7 8 1 2 3 4 5 6
-    d | 6 7 8 1 2 3 4 5
-    e | 5 6 7 8 1 2 3 4
-    f | 4 5 6 7 8 1 2 3
-    g | 3 4 5 6 7 8 1 2
-    h | 2 3 4 5 6 7 8 1
+	× | i j k l m n o p
+	--------------------
+	a | 1 2 3 4 5 6 7 8
+	b | 8 1 2 3 4 5 6 7
+	c | 7 8 1 2 3 4 5 6
+	d | 6 7 8 1 2 3 4 5
+	e | 5 6 7 8 1 2 3 4
+	f | 4 5 6 7 8 1 2 3
+	g | 3 4 5 6 7 8 1 2
+	h | 2 3 4 5 6 7 8 1
 ```
 
 2. Cases j == n_blocks && i < n_blocks, i == j && i < n_blocks, i == n_blocks && j == n_blocks: In such cases, it is not possible to shuffle data generally
 so there is no need to order calculations for each thread diagonally and it is also a bit more complicated to do so.
 That's why the calculations are done in the following order:
 ```
-    × | i j k l m n
-    ----------------
-    a | 1 2 3 4 5 6
-    b | 1 2 3 4 5 6
-    c | 1 2 3 4 5 6
-    d | 1 2 3 4 5 6
-    e | 1 2 3 4 5 6
-    f | 1 2 3 4 5 6
-    g | 1 2 3 4 5 6
-    h | 1 2 3 4 5 6
+	× | i j k l m n
+	----------------
+	a | 1 2 3 4 5 6
+	b | 1 2 3 4 5 6
+	c | 1 2 3 4 5 6
+	d | 1 2 3 4 5 6
+	e | 1 2 3 4 5 6
+	f | 1 2 3 4 5 6
+	g | 1 2 3 4 5 6
+	h | 1 2 3 4 5 6
 ```
 =#
 
@@ -277,9 +274,9 @@ function force_kernel!(
 	b = Int32(D)
 	n_blocks = Int32(ceil(N / 32))
 
-    # Get the indices that run on the blocks and threads
-    i = blockIdx().x
-    j = blockIdx().y
+	# Get the indices that run on the blocks and threads
+	i = blockIdx().x
+	j = blockIdx().y
 	i_0_tile = (i - 1) * warpsize()
 	j_0_tile = (j - 1) * warpsize()
 	index_i = i_0_tile + laneid()
@@ -297,7 +294,7 @@ function force_kernel!(
 	end
 
 
-    # The code is organised in 4 mutually excluding parts (this is the first (1) one)
+	# The code is organised in 4 mutually excluding parts (this is the first (1) one)
 	if j < n_blocks && i < j
 		d_block = zero(C)
 		dist_block = zero(C) * zero(C)
@@ -356,7 +353,7 @@ function force_kernel!(
 				atoms_j_shuffle = Atom(atype_j, aindex_j, amass_j, acharge_j, aσ_j, aϵ_j)
 				dr = vector(coords_j, coords_i, boundary)
 				r2 = sum(abs2, dr)
-				condition = eligible[laneid(), shuffle_idx] == true && Bool_excl == true && r2 <= r_cut * r_cut
+				condition = eligible[laneid(), shuffle_idx] && Bool_excl && r2 <= r_cut * r_cut
  				
 				f = condition ? sum_pairwise_forces(
 					inters_tuple,
@@ -426,7 +423,7 @@ function force_kernel!(
 				atoms_j = atoms[s_idx_j]
 				dr = vector(coords_j, coords_i, boundary)
 				r2 = sum(abs2, dr)
-				condition = eligible[laneid(), m] == true && Bool_excl == true && r2 <= r_cut * r_cut
+				condition = eligible[laneid(), m] && Bool_excl && r2 <= r_cut * r_cut
 
 				f = condition ? sum_pairwise_forces(
 					inters_tuple,
@@ -479,7 +476,7 @@ function force_kernel!(
 			atoms_j = atoms[s_idx_j]
 			dr = vector(coords_j, coords_i, boundary)
 			r2 = sum(abs2, dr)
-			condition = eligible[laneid(), m] == true && r2 <= r_cut * r_cut
+			condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
 
 			f = condition ? sum_pairwise_forces(
 				inters_tuple,
@@ -531,7 +528,7 @@ function force_kernel!(
 				atoms_j = atoms[s_idx_j]
 				dr = vector(coords_j, coords_i, boundary)
 				r2 = sum(abs2, dr)
-				condition = eligible[laneid(), m]== true && r2 <= r_cut * r_cut
+				condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
 				
 				f = condition ? sum_pairwise_forces(
 					inters_tuple,
@@ -557,7 +554,7 @@ function force_kernel!(
 		end
 	end
 
-    return nothing
+	return nothing
 end
 
 
@@ -588,9 +585,9 @@ function energy_kernel!(
 	n_blocks = Int32(ceil(N / 32))
 	r = Int32((N - 1) % 32 + 1)
 
-    # Indices and shared memory
-    i = blockIdx().x
-    j = blockIdx().y
+	# Indices and shared memory
+	i = blockIdx().x
+	j = blockIdx().y
 	i_0_tile = (i - 1) * warpsize()
 	j_0_tile = (j - 1) * warpsize()
 	index_i = i_0_tile + laneid()
@@ -600,7 +597,7 @@ function energy_kernel!(
 	eligible = CuStaticSharedArray(Bool, (32, 32))
 	special = CuStaticSharedArray(Bool, (32, 32))
 
-    # The code is organised in 4 mutually excluding parts (this is the first (1) one)
+	# The code is organised in 4 mutually excluding parts (this is the first (1) one)
 	if j < n_blocks && i < j
 		d_block = zero(C)
 		dist_block = zero(C) * zero(C)
@@ -657,8 +654,8 @@ function energy_kernel!(
 				
 				atoms_j_shuffle = Atom(atype_j, aindex_j, amass_j, acharge_j, aσ_j, aϵ_j)
 				dr = vector(coords_j, coords_i, boundary)
-				r2 = dr[1]^2 + dr[2]^2 + dr[3]^2
-				condition = eligible[laneid(), shuffle_idx] == true && Bool_excl == true && r2 <= r_cut * r_cut
+				r2 = sum(abs2, dr)
+				condition = eligible[laneid(), shuffle_idx] && Bool_excl && r2 <= r_cut * r_cut
 
 				pe = condition ? sum_pairwise_potentials(
 					inters_tuple,
@@ -712,8 +709,8 @@ function energy_kernel!(
 				vel_j = velocities[s_idx_j]
 				atoms_j = atoms[s_idx_j]
 				dr = vector(coords_j, coords_i, boundary)
-				r2 = dr[1]^2 + dr[2]^2 + dr[3]^2
-				condition = eligible[laneid(), m] == true && Bool_excl == true && r2 <= r_cut * r_cut
+				r2 = sum(abs2, dr)
+				condition = eligible[laneid(), m] && Bool_excl && r2 <= r_cut * r_cut
 
 				pe = condition ? sum_pairwise_potentials(
 					inters_tuple,
@@ -751,8 +748,8 @@ function energy_kernel!(
 			vel_j = velocities[s_idx_j]
 			atoms_j = atoms[s_idx_j]
 			dr = vector(coords_j, coords_i, boundary)
-			r2 = dr[1]^2 + dr[2]^2 + dr[3]^2
-			condition = eligible[laneid(), m] == true && r2 <= r_cut * r_cut
+			r2 = sum(abs2, dr)
+			condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
 
 			pe = condition ? sum_pairwise_potentials(
 					inters_tuple,
@@ -791,8 +788,8 @@ function energy_kernel!(
 				vel_j = velocities[s_idx_j]
 				atoms_j = atoms[s_idx_j]
 				dr = vector(coords_j, coords_i, boundary)
-				r2 = dr[1]^2 + dr[2]^2 + dr[3]^2
-				condition = eligible[laneid(), m] == true && r2 <= r_cut * r_cut
+				r2 = sum(abs2, dr)
+				condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
 				
 				pe = condition ? sum_pairwise_potentials(
 					inters_tuple,
@@ -810,423 +807,423 @@ function energy_kernel!(
 	end
 
 	if threadIdx().x == a
-		sum = T(0.0)
+		sum_E = zero(T)
 		for k in a:warpsize()
-			sum += E_smem[k]
+			sum_E += E_smem[k]
 		end
-		CUDA.atomic_add!(pointer(energy_nounits), sum)
+		CUDA.atomic_add!(pointer(energy_nounits), sum_E)
 	end
-    return nothing
+	return nothing
 end
 
 
 
 function pairwise_force_kernel_nonl!(forces::AbstractArray{T}, coords_var, velocities_var,
-                        atoms_var, boundary, inters, step_n, ::Val{D}, ::Val{F}) where {T, D, F}
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    n_atoms = length(atoms)
+						atoms_var, boundary, inters, step_n, ::Val{D}, ::Val{F}) where {T, D, F}
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	n_atoms = length(atoms)
 
-    tidx = threadIdx().x
-    i_0_tile = (blockIdx().x - 1) * warpsize()
-    j_0_block = (blockIdx().y - 1) * blockDim().x
-    warpidx = cld(tidx, warpsize())
-    j_0_tile = j_0_block + (warpidx - 1) * warpsize()
-    i = i_0_tile + laneid()
+	tidx = threadIdx().x
+	i_0_tile = (blockIdx().x - 1) * warpsize()
+	j_0_block = (blockIdx().y - 1) * blockDim().x
+	warpidx = cld(tidx, warpsize())
+	j_0_tile = j_0_block + (warpidx - 1) * warpsize()
+	i = i_0_tile + laneid()
 
-    forces_shmem = CuStaticSharedArray(T, (3, 1024))
-    @inbounds for dim in 1:3
-        forces_shmem[dim, tidx] = zero(T)
-    end
+	forces_shmem = CuStaticSharedArray(T, (3, 1024))
+	@inbounds for dim in 1:3
+		forces_shmem[dim, tidx] = zero(T)
+	end
 
-    if i_0_tile + warpsize() > n_atoms || j_0_tile + warpsize() > n_atoms
-        @inbounds if i <= n_atoms
-            njs = min(warpsize(), n_atoms - j_0_tile)
-            atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
-            for del_j in 1:njs
-                j = j_0_tile + del_j
-                if i != j
-                    atom_j, coord_j, vel_j = atoms[j], coords[j], velocities[j]
-                    f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
-                                            boundary, vel_i, vel_j, step_n)
-                    for dim in 1:D
-                        forces_shmem[dim, tidx] += -ustrip(f[dim])
-                    end
-                end
-            end
+	if i_0_tile + warpsize() > n_atoms || j_0_tile + warpsize() > n_atoms
+		@inbounds if i <= n_atoms
+			njs = min(warpsize(), n_atoms - j_0_tile)
+			atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
+			for del_j in 1:njs
+				j = j_0_tile + del_j
+				if i != j
+					atom_j, coord_j, vel_j = atoms[j], coords[j], velocities[j]
+					f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
+											boundary, vel_i, vel_j, step_n)
+					for dim in 1:D
+						forces_shmem[dim, tidx] += -ustrip(f[dim])
+					end
+				end
+			end
 
-            for dim in 1:D
-                Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
-            end
-        end
-    else
-        j = j_0_tile + laneid()
-        tilesteps = warpsize()
-        if i_0_tile == j_0_tile  # To not compute i-i forces
-            j = j_0_tile + laneid() % warpsize() + 1
-            tilesteps -= 1
-        end
+			for dim in 1:D
+				Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
+			end
+		end
+	else
+		j = j_0_tile + laneid()
+		tilesteps = warpsize()
+		if i_0_tile == j_0_tile  # To not compute i-i forces
+			j = j_0_tile + laneid() % warpsize() + 1
+			tilesteps -= 1
+		end
 
-        atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
-        coord_j, vel_j = coords[j], velocities[j]
-        @inbounds for _ in 1:tilesteps
-            sync_warp()
-            atom_j = atoms[j]
-            f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
-                                    boundary, vel_i, vel_j, step_n)
-            for dim in 1:D
-                forces_shmem[dim, tidx] += -ustrip(f[dim])
-            end
-            @shfl_multiple_sync(FULL_MASK, laneid() + 1, warpsize(), j, coord_j)
-        end
+		atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
+		coord_j, vel_j = coords[j], velocities[j]
+		@inbounds for _ in 1:tilesteps
+			sync_warp()
+			atom_j = atoms[j]
+			f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
+									boundary, vel_i, vel_j, step_n)
+			for dim in 1:D
+				forces_shmem[dim, tidx] += -ustrip(f[dim])
+			end
+			@shfl_multiple_sync(FULL_MASK, laneid() + 1, warpsize(), j, coord_j)
+		end
 
-        @inbounds for dim in 1:D
-            Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
-        end
-    end
+		@inbounds for dim in 1:D
+			Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
+		end
+	end
 
-    return nothing
+	return nothing
 end
 
 function pairwise_pe_kernel!(energy, coords_var, velocities_var, atoms_var, boundary, inters,
-                             neighbors_var, step_n, ::Val{E}) where E
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    neighbors = CUDA.Const(neighbors_var)
+							 neighbors_var, step_n, ::Val{E}) where E
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	neighbors = CUDA.Const(neighbors_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(neighbors)
-        i, j, special = neighbors[inter_i]
-        coord_i, coord_j, vel_i, vel_j = coords[i], coords[j], velocities[i], velocities[j]
-        dr = vector(coord_i, coord_j, boundary)
-        pe = potential_energy_gpu(inters[1], dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
-                                  boundary, vel_i, vel_j, step_n)
-        for inter in inters[2:end]
-            pe += potential_energy_gpu(inter, dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
-                                       boundary, vel_i, vel_j, step_n)
-        end
-        if unit(pe) != E
-            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-        end
-        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-    end
-    return nothing
+	@inbounds if inter_i <= length(neighbors)
+		i, j, special = neighbors[inter_i]
+		coord_i, coord_j, vel_i, vel_j = coords[i], coords[j], velocities[i], velocities[j]
+		dr = vector(coord_i, coord_j, boundary)
+		pe = potential_energy_gpu(inters[1], dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
+								  boundary, vel_i, vel_j, step_n)
+		for inter in inters[2:end]
+			pe += potential_energy_gpu(inter, dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
+									   boundary, vel_i, vel_j, step_n)
+		end
+		if unit(pe) != E
+			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+		end
+		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+	end
+	return nothing
 end
 
 @inline function sum_pairwise_forces(inters, atom_i, atom_j, ::Val{F}, special, coord_i, coord_j,
-                                     boundary, vel_i, vel_j, step_n) where F
-    dr = vector(coord_i, coord_j, boundary)
-    f_tuple = ntuple(length(inters)) do inter_type_i
-        force_gpu(inters[inter_type_i], dr, atom_i, atom_j, F, special, coord_i, coord_j, boundary,
-                  vel_i, vel_j, step_n)
-    end
-    f = sum(f_tuple)
-    if unit(f[1]) != F
-        # This triggers an error but it isn't printed
-        # See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
-        #   for how to throw a more meaningful error
-        error("wrong force unit returned, was expecting $F but got $(unit(f[1]))")
-    end
-    return f
+									 boundary, vel_i, vel_j, step_n) where F
+	dr = vector(coord_i, coord_j, boundary)
+	f_tuple = ntuple(length(inters)) do inter_type_i
+		force_gpu(inters[inter_type_i], dr, atom_i, atom_j, F, special, coord_i, coord_j, boundary,
+				  vel_i, vel_j, step_n)
+	end
+	f = sum(f_tuple)
+	if unit(f[1]) != F
+		# This triggers an error but it isn't printed
+		# See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
+		#   for how to throw a more meaningful error
+		error("wrong force unit returned, was expecting $F but got $(unit(f[1]))")
+	end
+	return f
 end
 
 @inline function sum_pairwise_potentials(inters, atom_i, atom_j, ::Val{E}, special, coord_i, coord_j,
-                                     boundary, vel_i, vel_j, step_n) where E
-    dr = vector(coord_i, coord_j, boundary)
+									 boundary, vel_i, vel_j, step_n) where E
+	dr = vector(coord_i, coord_j, boundary)
 
-    pe_tuple = ntuple(length(inters)) do inter_type_i
-        SVector(potential_energy_gpu(inters[inter_type_i], dr, atom_i, atom_j, E, special, coord_i, coord_j, boundary,
-                  vel_i, vel_j, step_n))
-				  # why? 
-    end
-    pe = sum(pe_tuple)
-    if unit(pe[1]) != E
-        # This triggers an error but it isn't printed
-        # See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
-        #   for how to throw a more meaningful error
-        error("wrong force unit returned, was expecting $E but got $(unit(pe[1]))")
-    end
-    return pe
+	pe_tuple = ntuple(length(inters)) do inter_type_i
+		SVector(potential_energy_gpu(inters[inter_type_i], dr, atom_i, atom_j, E, special, coord_i, coord_j, boundary,
+				  vel_i, vel_j, step_n))
+				  # SVector was required to avoid a GPU error occurring with scalars (like the quantity returned by potential_energy_gpu) 
+	end
+	pe = sum(pe_tuple)
+	if unit(pe[1]) != E
+		# This triggers an error but it isn't printed
+		# See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
+		#   for how to throw a more meaningful error
+		error("wrong force unit returned, was expecting $E but got $(unit(pe[1]))")
+	end
+	return pe
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList1Atoms, coords::AbstractArray{SVector{D, C}},
-                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_1_atoms_kernel!(fs_mat,
-            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.inters,
-            Val(D), Val(force_units))
-    return fs_mat
+							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_1_atoms_kernel!(fs_mat,
+			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.inters,
+			Val(D), Val(force_units))
+	return fs_mat
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList2Atoms, coords::AbstractArray{SVector{D, C}},
-                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_2_atoms_kernel!(fs_mat,
-            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
-            inter_list.inters, Val(D), Val(force_units))
-    return fs_mat
+							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_2_atoms_kernel!(fs_mat,
+			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
+			inter_list.inters, Val(D), Val(force_units))
+	return fs_mat
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList3Atoms, coords::AbstractArray{SVector{D, C}},
-                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_3_atoms_kernel!(fs_mat,
-            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
-            inter_list.ks, inter_list.inters, Val(D), Val(force_units))
-    return fs_mat
+							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_3_atoms_kernel!(fs_mat,
+			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
+			inter_list.ks, inter_list.inters, Val(D), Val(force_units))
+	return fs_mat
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList4Atoms, coords::AbstractArray{SVector{D, C}},
-                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_4_atoms_kernel!(fs_mat,
-            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
-            inter_list.ks, inter_list.ls, inter_list.inters, Val(D), Val(force_units))
-    return fs_mat
+							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_4_atoms_kernel!(fs_mat,
+			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
+			inter_list.ks, inter_list.ls, inter_list.inters, Val(D), Val(force_units))
+	return fs_mat
 end
 
 function specific_force_1_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-                        step_n, is_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    inters = CUDA.Const(inters_var)
+						step_n, is_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i = is[inter_i]
-        fs = force_gpu(inters[inter_i], coords[i], boundary, atoms[i], F, velocities[i], step_n)
-        if unit(fs.f1[1]) != F
-            error("wrong force unit returned, was expecting $F")
-        end
-        for dim in 1:D
-            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-        end
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i = is[inter_i]
+		fs = force_gpu(inters[inter_i], coords[i], boundary, atoms[i], F, velocities[i], step_n)
+		if unit(fs.f1[1]) != F
+			error("wrong force unit returned, was expecting $F")
+		end
+		for dim in 1:D
+			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+		end
+	end
+	return nothing
 end
 
 function specific_force_2_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-                        step_n, is_var, js_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    js = CUDA.Const(js_var)
-    inters = CUDA.Const(inters_var)
+						step_n, is_var, js_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	js = CUDA.Const(js_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i, j = is[inter_i], js[inter_i]
-        fs = force_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i], atoms[j], F,
-                       velocities[i], velocities[j], step_n)
-        if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F
-            error("wrong force unit returned, was expecting $F")
-        end
-        for dim in 1:D
-            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-            Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
-        end
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i, j = is[inter_i], js[inter_i]
+		fs = force_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i], atoms[j], F,
+					   velocities[i], velocities[j], step_n)
+		if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F
+			error("wrong force unit returned, was expecting $F")
+		end
+		for dim in 1:D
+			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+			Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
+		end
+	end
+	return nothing
 end
 
 function specific_force_3_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-                        step_n, is_var, js_var, ks_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    js = CUDA.Const(js_var)
-    ks = CUDA.Const(ks_var)
-    inters = CUDA.Const(inters_var)
+						step_n, is_var, js_var, ks_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	js = CUDA.Const(js_var)
+	ks = CUDA.Const(ks_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i, j, k = is[inter_i], js[inter_i], ks[inter_i]
-        fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary, atoms[i],
-                       atoms[j], atoms[k], F, velocities[i], velocities[j], velocities[k], step_n)
-        if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F
-            error("wrong force unit returned, was expecting $F")
-        end
-        for dim in 1:D
-            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-            Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
-            Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
-        end
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i, j, k = is[inter_i], js[inter_i], ks[inter_i]
+		fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary, atoms[i],
+					   atoms[j], atoms[k], F, velocities[i], velocities[j], velocities[k], step_n)
+		if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F
+			error("wrong force unit returned, was expecting $F")
+		end
+		for dim in 1:D
+			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+			Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
+			Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
+		end
+	end
+	return nothing
 end
 
 function specific_force_4_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-                        step_n, is_var, js_var, ks_var, ls_var, inters_var,
-                        ::Val{D}, ::Val{F}) where {D, F}
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    js = CUDA.Const(js_var)
-    ks = CUDA.Const(ks_var)
-    ls = CUDA.Const(ls_var)
-    inters = CUDA.Const(inters_var)
+						step_n, is_var, js_var, ks_var, ls_var, inters_var,
+						::Val{D}, ::Val{F}) where {D, F}
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	js = CUDA.Const(js_var)
+	ks = CUDA.Const(ks_var)
+	ls = CUDA.Const(ls_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
-        fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l], boundary,
-                       atoms[i], atoms[j], atoms[k], atoms[l], F, velocities[i], velocities[j],
-                       velocities[k], velocities[l], step_n)
-        if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F || unit(fs.f4[1]) != F
-            error("wrong force unit returned, was expecting $F")
-        end
-        for dim in 1:D
-            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-            Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
-            Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
-            Atomix.@atomic :monotonic forces[dim, l] += ustrip(fs.f4[dim])
-        end
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
+		fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l], boundary,
+					   atoms[i], atoms[j], atoms[k], atoms[l], F, velocities[i], velocities[j],
+					   velocities[k], velocities[l], step_n)
+		if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F || unit(fs.f4[1]) != F
+			error("wrong force unit returned, was expecting $F")
+		end
+		for dim in 1:D
+			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+			Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
+			Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
+			Atomix.@atomic :monotonic forces[dim, l] += ustrip(fs.f4[dim])
+		end
+	end
+	return nothing
 end
 
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList1Atoms, coords::AbstractArray{SVector{D, C}},
-                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_1_atoms_kernel!(
-            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-            inter_list.inters, Val(energy_units))
-    return pe_vec_nounits
+						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_1_atoms_kernel!(
+			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+			inter_list.inters, Val(energy_units))
+	return pe_vec_nounits
 end
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList2Atoms, coords::AbstractArray{SVector{D, C}},
-                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_2_atoms_kernel!(
-            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-            inter_list.js, inter_list.inters, Val(energy_units))
-    return pe_vec_nounits
+						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_2_atoms_kernel!(
+			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+			inter_list.js, inter_list.inters, Val(energy_units))
+	return pe_vec_nounits
 end
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList3Atoms, coords::AbstractArray{SVector{D, C}},
-                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_3_atoms_kernel!(
-            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-            inter_list.js, inter_list.ks, inter_list.inters, Val(energy_units))
-    return pe_vec_nounits
+						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_3_atoms_kernel!(
+			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+			inter_list.js, inter_list.ks, inter_list.inters, Val(energy_units))
+	return pe_vec_nounits
 end
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList4Atoms, coords::AbstractArray{SVector{D, C}},
-                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_4_atoms_kernel!(
-            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-            inter_list.js, inter_list.ks, inter_list.ls, inter_list.inters, Val(energy_units))
-    return pe_vec_nounits
+						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_4_atoms_kernel!(
+			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+			inter_list.js, inter_list.ks, inter_list.ls, inter_list.inters, Val(energy_units))
+	return pe_vec_nounits
 end
 
 function specific_pe_1_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-                    step_n, is_var, inters_var, ::Val{E}) where E
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    inters = CUDA.Const(inters_var)
+					step_n, is_var, inters_var, ::Val{E}) where E
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i = is[inter_i]
-        pe = potential_energy_gpu(inters[inter_i], coords[i], boundary, atoms[i], E,
-                                  velocities[i], step_n)
-        if unit(pe) != E
-            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-        end
-        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i = is[inter_i]
+		pe = potential_energy_gpu(inters[inter_i], coords[i], boundary, atoms[i], E,
+								  velocities[i], step_n)
+		if unit(pe) != E
+			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+		end
+		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+	end
+	return nothing
 end
 
 function specific_pe_2_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-                    step_n, is_var, js_var, inters_var, ::Val{E}) where E
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    js = CUDA.Const(js_var)
-    inters = CUDA.Const(inters_var)
+					step_n, is_var, js_var, inters_var, ::Val{E}) where E
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	js = CUDA.Const(js_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i, j = is[inter_i], js[inter_i]
-        pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i],
-                                  atoms[j], E, velocities[i], velocities[j], step_n)
-        if unit(pe) != E
-            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-        end
-        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i, j = is[inter_i], js[inter_i]
+		pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i],
+								  atoms[j], E, velocities[i], velocities[j], step_n)
+		if unit(pe) != E
+			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+		end
+		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+	end
+	return nothing
 end
 
 function specific_pe_3_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-                    step_n, is_var, js_var, ks_var, inters_var, ::Val{E}) where E
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    js = CUDA.Const(js_var)
-    ks = CUDA.Const(ks_var)
-    inters = CUDA.Const(inters_var)
+					step_n, is_var, js_var, ks_var, inters_var, ::Val{E}) where E
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	js = CUDA.Const(js_var)
+	ks = CUDA.Const(ks_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i, j, k = is[inter_i], js[inter_i], ks[inter_i]
-        pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary,
-                                  atoms[i], atoms[j], atoms[k], E, velocities[i], velocities[j],
-                                  velocities[k], step_n)
-        if unit(pe) != E
-            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-        end
-        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i, j, k = is[inter_i], js[inter_i], ks[inter_i]
+		pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary,
+								  atoms[i], atoms[j], atoms[k], E, velocities[i], velocities[j],
+								  velocities[k], step_n)
+		if unit(pe) != E
+			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+		end
+		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+	end
+	return nothing
 end
 
 function specific_pe_4_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-                    step_n, is_var, js_var, ks_var, ls_var, inters_var, ::Val{E}) where E
-    coords = CUDA.Const(coords_var)
-    velocities = CUDA.Const(velocities_var)
-    atoms = CUDA.Const(atoms_var)
-    is = CUDA.Const(is_var)
-    js = CUDA.Const(js_var)
-    ks = CUDA.Const(ks_var)
-    ls = CUDA.Const(ls_var)
-    inters = CUDA.Const(inters_var)
+					step_n, is_var, js_var, ks_var, ls_var, inters_var, ::Val{E}) where E
+	coords = CUDA.Const(coords_var)
+	velocities = CUDA.Const(velocities_var)
+	atoms = CUDA.Const(atoms_var)
+	is = CUDA.Const(is_var)
+	js = CUDA.Const(js_var)
+	ks = CUDA.Const(ks_var)
+	ls = CUDA.Const(ls_var)
+	inters = CUDA.Const(inters_var)
 
-    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-    @inbounds if inter_i <= length(is)
-        i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
-        pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l],
-                                  boundary, atoms[i], atoms[j], atoms[k], atoms[l], E,
-                                  velocities[i], velocities[j], velocities[k], velocities[l],
-                                  step_n)
-        if unit(pe) != E
-            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-        end
-        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-    end
-    return nothing
+	@inbounds if inter_i <= length(is)
+		i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
+		pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l],
+								  boundary, atoms[i], atoms[j], atoms[k], atoms[l], E,
+								  velocities[i], velocities[j], velocities[k], velocities[l],
+								  step_n)
+		if unit(pe) != E
+			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+		end
+		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+	end
+	return nothing
 end

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -2,14 +2,14 @@
 const WARPSIZE = UInt32(32)
 
 macro shfl_multiple_sync(mask, target, width, vars...)
-	all_lines = map(vars) do v
-		Expr(:(=), v,
-			Expr(:call, :shfl_sync,
-				mask, v, target, width
-			)
-		)
-	end
-	return esc(Expr(:block, all_lines...))
+    all_lines = map(vars) do v
+        Expr(:(=), v,
+            Expr(:call, :shfl_sync,
+                mask, v, target, width
+            )
+        )
+    end
+    return esc(Expr(:block, all_lines...))
 end
 
 CUDA.shfl_recurse(op, x::Quantity) = op(x.val) * unit(x)
@@ -18,81 +18,81 @@ CUDA.shfl_recurse(op, x::SVector{2, C}) where C = SVector{2, C}(op(x[1]), op(x[2
 CUDA.shfl_recurse(op, x::SVector{3, C}) where C = SVector{3, C}(op(x[1]), op(x[2]), op(x[3]))
 
 function cuda_threads_blocks_pairwise(n_neighbors)
-	n_threads_gpu = min(n_neighbors, parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512")))
-	n_blocks = cld(n_neighbors, n_threads_gpu)
-	return n_threads_gpu, n_blocks
+    n_threads_gpu = min(n_neighbors, parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512")))
+    n_blocks = cld(n_neighbors, n_threads_gpu)
+    return n_threads_gpu, n_blocks
 end
 
 function cuda_threads_blocks_specific(n_inters)
-	n_threads_gpu = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_SPECIFIC", "128"))
-	n_blocks = cld(n_inters, n_threads_gpu)
-	return n_threads_gpu, n_blocks
+    n_threads_gpu = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_SPECIFIC", "128"))
+    n_blocks = cld(n_inters, n_threads_gpu)
+    return n_threads_gpu, n_blocks
 end
 
 function pairwise_force_gpu!(buffers, sys::System{D, true, T}, pairwise_inters, nbs, step_n) where {D, T}
-	if typeof(nbs) == NoNeighborList
-		kernel = @cuda launch=false pairwise_force_kernel_nonl!(
-				buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n,
-				Val(D), Val(sys.force_units))
-		conf = launch_configuration(kernel.fun)
-		threads_basic = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512"))
-		nthreads = min(length(sys.atoms), threads_basic, conf.threads)
-		nthreads = cld(nthreads, WARPSIZE) * WARPSIZE
-		n_blocks_i = cld(length(sys.atoms), WARPSIZE)
-		n_blocks_j = cld(length(sys.atoms), nthreads)
-		kernel(buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n, Val(D),
-			   Val(sys.force_units); threads=nthreads, blocks=(n_blocks_i, n_blocks_j))
-	else    
-		N = length(sys.coords)
-		n_blocks = cld(N, WARPSIZE)
-		r_cut = sys.neighbor_finder.dist_cutoff
-		if step_n % sys.neighbor_finder.n_steps_reorder == 0 || step_n == 1 || !sys.neighbor_finder.initialized
-			Morton_bits = 4
-			w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
-			Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
-			copyto!(buffers.Morton_seq, Morton_seq_cpu)
-			CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary, Val(D))
-			sys.neighbor_finder.initialized = true
-			CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true compress_boolean_matrices!(buffers.Morton_seq, 
-			sys.neighbor_finder.eligible, sys.neighbor_finder.special, buffers.compressed_eligible, buffers.compressed_special, Val(N))
-		end
-		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true force_kernel!(buffers.Morton_seq, buffers.fs_mat, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.force_units), pairwise_inters, sys.boundary, step_n, buffers.compressed_special, buffers.compressed_eligible, Val(T), Val(D))
-	end
-	return buffers
+    if typeof(nbs) == NoNeighborList
+        kernel = @cuda launch=false pairwise_force_kernel_nonl!(
+                buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n,
+                Val(D), Val(sys.force_units))
+        conf = launch_configuration(kernel.fun)
+        threads_basic = parse(Int, get(ENV, "MOLLY_GPUNTHREADS_PAIRWISE", "512"))
+        nthreads = min(length(sys.atoms), threads_basic, conf.threads)
+        nthreads = cld(nthreads, WARPSIZE) * WARPSIZE
+        n_blocks_i = cld(length(sys.atoms), WARPSIZE)
+        n_blocks_j = cld(length(sys.atoms), nthreads)
+        kernel(buffers.fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, step_n, Val(D),
+               Val(sys.force_units); threads=nthreads, blocks=(n_blocks_i, n_blocks_j))
+    else    
+        N = length(sys.coords)
+        n_blocks = cld(N, WARPSIZE)
+        r_cut = sys.neighbor_finder.dist_cutoff
+        if step_n % sys.neighbor_finder.n_steps_reorder == 0 || step_n == 1 || !sys.neighbor_finder.initialized
+            Morton_bits = 4
+            w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
+            Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
+            copyto!(buffers.Morton_seq, Morton_seq_cpu)
+            CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary, Val(D))
+            sys.neighbor_finder.initialized = true
+            CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true compress_boolean_matrices!(buffers.Morton_seq, 
+            sys.neighbor_finder.eligible, sys.neighbor_finder.special, buffers.compressed_eligible, buffers.compressed_special, Val(N))
+        end
+        CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true force_kernel!(buffers.Morton_seq, buffers.fs_mat, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.force_units), pairwise_inters, sys.boundary, step_n, buffers.compressed_special, buffers.compressed_eligible, Val(T), Val(D))
+    end
+    return buffers
 end
 
 function pairwise_pe_gpu!(pe_vec_nounits, buffers, sys::System{D, true, T}, pairwise_inters, nbs, step_n) where {D, T}
-	if typeof(nbs) == NoNeighborList
-		n_threads_gpu, n_blocks = cuda_threads_blocks_pairwise(length(nbs))
-		CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks pairwise_pe_kernel!(
-			pe_vec_nounits, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, nbs, step_n, Val(sys.energy_units))
-	else
-		N = length(sys.coords)
-		n_blocks = cld(N, WARPSIZE)
-		r_cut = sys.neighbor_finder.dist_cutoff
-		Morton_bits = 4
-		w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
-		Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
-		copyto!(buffers.Morton_seq, Morton_seq_cpu)
-		CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary, Val(D))
-		sys.neighbor_finder.initialized = true
-		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true energy_kernel!(buffers.Morton_seq, 
-			pe_vec_nounits, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.energy_units), 
-			pairwise_inters, sys.boundary, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, Val(T), Val(D))
-	end
-	return pe_vec_nounits
+    if typeof(nbs) == NoNeighborList
+        n_threads_gpu, n_blocks = cuda_threads_blocks_pairwise(length(nbs))
+        CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks pairwise_pe_kernel!(
+            pe_vec_nounits, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters, nbs, step_n, Val(sys.energy_units))
+    else
+        N = length(sys.coords)
+        n_blocks = cld(N, WARPSIZE)
+        r_cut = sys.neighbor_finder.dist_cutoff
+        Morton_bits = 4
+        w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
+        Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)
+        copyto!(buffers.Morton_seq, Morton_seq_cpu)
+        CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary, Val(D))
+        sys.neighbor_finder.initialized = true
+        CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true energy_kernel!(buffers.Morton_seq, 
+            pe_vec_nounits, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.energy_units), 
+            pairwise_inters, sys.boundary, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, Val(T), Val(D))
+    end
+    return pe_vec_nounits
 end
 
 function sorted_Morton_seq(positions, w, bits::Int)
-	N = length(positions)
-	D = length(positions[1])
-	Morton_sequence = Vector{Int32}(undef, N)
-	for i in 1:N
-		scaled_coords = floor.(Int32, positions[i] ./ w)
-		Morton_sequence[i] = generalized_Morton_code(scaled_coords, bits, D)
-	end
-	sort = Int32.(sortperm(Morton_sequence))
-	return sort
+    N = length(positions)
+    D = length(positions[1])
+    Morton_sequence = Vector{Int32}(undef, N)
+    for i in 1:N
+        scaled_coords = floor.(Int32, positions[i] ./ w)
+        Morton_sequence[i] = generalized_Morton_code(scaled_coords, bits, D)
+    end
+    sort = Int32.(sortperm(Morton_sequence))
+    return sort
 end
 
 function generalized_Morton_code(indices, bits::Int, D::Int)
@@ -107,158 +107,158 @@ end
 
 function boxes_dist(x1_min::D, x1_max::D, x2_min::D, x2_max::D, Lx::D) where D
 
-	a = abs(vector_1D(x2_max, x1_min, Lx))
-	b = abs(vector_1D(x1_max, x2_min, Lx))
+    a = abs(vector_1D(x2_max, x1_min, Lx))
+    b = abs(vector_1D(x1_max, x2_min, Lx))
 
-	return ifelse(
-		x1_min - x2_max <= zero(D) && x2_min - x1_max <= zero(D),
-		zero(D),
-		ifelse(a < b, a, b)	
-	)
+    return ifelse(
+        x1_min - x2_max <= zero(D) && x2_min - x1_max <= zero(D),
+        zero(D),
+        ifelse(a < b, a, b)	
+    )
 end
 
 function kernel_min_max!(
-	sorted_seq,
-	mins::AbstractArray{C}, 
-	maxs::AbstractArray{C}, 
-	coords, 
-	::Val{n}, 
-	boundary,
-	::Val{D}) where {n, C, D}
+    sorted_seq,
+    mins::AbstractArray{C}, 
+    maxs::AbstractArray{C}, 
+    coords, 
+    ::Val{n}, 
+    boundary,
+    ::Val{D}) where {n, C, D}
 
-	D32 = Int32(32)
-	a = Int32(1)
-	b = Int32(D)
-	r = Int32(n % D32)
-	i = threadIdx().x + (blockIdx().x - a) * blockDim().x
-	local_i = threadIdx().x
-	mins_smem = CuStaticSharedArray(C, (D32, b))
-	maxs_smem = CuStaticSharedArray(C, (D32, b))
-	r_smem = CuStaticSharedArray(C, (r, b))
+    D32 = Int32(32)
+    a = Int32(1)
+    b = Int32(D)
+    r = Int32(n % D32)
+    i = threadIdx().x + (blockIdx().x - a) * blockDim().x
+    local_i = threadIdx().x
+    mins_smem = CuStaticSharedArray(C, (D32, b))
+    maxs_smem = CuStaticSharedArray(C, (D32, b))
+    r_smem = CuStaticSharedArray(C, (r, b))
  
-	if i <= n - r && local_i <= D32
-		for k in a:b
-			s_i = sorted_seq[i]
-			mins_smem[local_i, k] = coords[s_i][k]
-			maxs_smem[local_i, k] = coords[s_i][k]
-		end
-	end
-	sync_threads() 
-	if i <= n - r && local_i <= D32
-		for p in a:Int32(log2(D32))
-			for k in a:b
-				@inbounds begin
-					if local_i % Int32(2^p) == Int32(0)
-						if mins_smem[local_i, k] > mins_smem[local_i - Int32(2^(p - 1)), k] 
-							mins_smem[local_i, k] = mins_smem[local_i - Int32(2^(p - 1)), k]
-						end
-						if maxs_smem[local_i, k] < maxs_smem[local_i - Int32(2^(p - 1)), k] 
-							maxs_smem[local_i, k] = maxs_smem[local_i - Int32(2^(p - 1)), k]
-						end
-					end
-				end
-			end
-		end 
-		if local_i == D32 
-			for k in a:b
-				mins[blockIdx().x, k] = mins_smem[local_i, k]
-				maxs[blockIdx().x, k] = maxs_smem[local_i, k]
-			end
-		end
+    if i <= n - r && local_i <= D32
+        for k in a:b
+            s_i = sorted_seq[i]
+            mins_smem[local_i, k] = coords[s_i][k]
+            maxs_smem[local_i, k] = coords[s_i][k]
+        end
+    end
+    sync_threads() 
+    if i <= n - r && local_i <= D32
+        for p in a:Int32(log2(D32))
+            for k in a:b
+                @inbounds begin
+                    if local_i % Int32(2^p) == Int32(0)
+                        if mins_smem[local_i, k] > mins_smem[local_i - Int32(2^(p - 1)), k] 
+                            mins_smem[local_i, k] = mins_smem[local_i - Int32(2^(p - 1)), k]
+                        end
+                        if maxs_smem[local_i, k] < maxs_smem[local_i - Int32(2^(p - 1)), k] 
+                            maxs_smem[local_i, k] = maxs_smem[local_i - Int32(2^(p - 1)), k]
+                        end
+                    end
+                end
+            end
+        end 
+        if local_i == D32 
+            for k in a:b
+                mins[blockIdx().x, k] = mins_smem[local_i, k]
+                maxs[blockIdx().x, k] = maxs_smem[local_i, k]
+            end
+        end
 
-	end 
+    end 
 
-	# Since the remainder array is low-dimensional, we do the scan
-	if i > n - r && i <= n && local_i <= r
-		for k in a:b
-			r_smem[local_i, k] = coords[sorted_seq[i]][k]
-		end
-	end
-	xyz_min = CuStaticSharedArray(C, b)
-	xyz_max = CuStaticSharedArray(C, b)
-	for k in a:b
-		xyz_min[k] = 10 * boundary.side_lengths[k] # very large (arbitrary) value
-		xyz_max[k] = -10 * boundary.side_lengths[k]
-	end
-	if local_i == a
-		for j in a:r
-			@inbounds begin
-				for k in a:b
-					if r_smem[j, k] < xyz_min[k] 
-						xyz_min[k] = r_smem[j, k]
-					end
-					if r_smem[j, k] > xyz_max[k] 
-						xyz_max[k] = r_smem[j, k]
-					end
-				end
-			end
-		end
-		if blockIdx().x == Int32(ceil(n/D32)) && r != Int32(0)
-			for k in a:b
-				mins[blockIdx().x, k] = xyz_min[k] 
-				maxs[blockIdx().x, k] = xyz_max[k]
-			end
-		end
-	end
+    # Since the remainder array is low-dimensional, we do the scan
+    if i > n - r && i <= n && local_i <= r
+        for k in a:b
+            r_smem[local_i, k] = coords[sorted_seq[i]][k]
+        end
+    end
+    xyz_min = CuStaticSharedArray(C, b)
+    xyz_max = CuStaticSharedArray(C, b)
+    for k in a:b
+        xyz_min[k] = 10 * boundary.side_lengths[k] # very large (arbitrary) value
+        xyz_max[k] = -10 * boundary.side_lengths[k]
+    end
+    if local_i == a
+        for j in a:r
+            @inbounds begin
+                for k in a:b
+                    if r_smem[j, k] < xyz_min[k] 
+                        xyz_min[k] = r_smem[j, k]
+                    end
+                    if r_smem[j, k] > xyz_max[k] 
+                        xyz_max[k] = r_smem[j, k]
+                    end
+                end
+            end
+        end
+        if blockIdx().x == Int32(ceil(n/D32)) && r != Int32(0)
+            for k in a:b
+                mins[blockIdx().x, k] = xyz_min[k] 
+                maxs[blockIdx().x, k] = xyz_max[k]
+            end
+        end
+    end
 
-	return nothing
+    return nothing
 end
 
 function compress_boolean_matrices!(sorted_seq, eligible_matrix, special_matrix, compressed_eligible, compressed_special, ::Val{N}) where N
 
-	a = Int32(1)
-	n_blocks = Int32(ceil(N / 32))
-	r = Int32((N - 1) % 32 + 1)
-	i = blockIdx().x
-	j = blockIdx().y
-	i_0_tile = (i - a) * warpsize()
-	j_0_tile = (j - a) * warpsize()
-	index_i = i_0_tile + laneid()
-	index_j = j_0_tile + laneid()
+    a = Int32(1)
+    n_blocks = Int32(ceil(N / 32))
+    r = Int32((N - 1) % 32 + 1)
+    i = blockIdx().x
+    j = blockIdx().y
+    i_0_tile = (i - a) * warpsize()
+    j_0_tile = (j - a) * warpsize()
+    index_i = i_0_tile + laneid()
+    index_j = j_0_tile + laneid()
 
-	if j < n_blocks && i <= j 
-		s_idx_i = sorted_seq[index_i]
-		eligible_bitmask = UInt32(0)
-		special_bitmask = UInt32(0)
-		for m in a:warpsize()
-			s_idx_j = sorted_seq[j_0_tile + m]
-			eligible_bitmask = (eligible_bitmask << 1) | UInt32(eligible_matrix[s_idx_i, s_idx_j])
-			special_bitmask = (special_bitmask << 1) | UInt32(special_matrix[s_idx_i, s_idx_j])
-		end
-		compressed_eligible[laneid(), i, j] = eligible_bitmask
-		compressed_special[laneid(), i, j] = special_bitmask
-	end
+    if j < n_blocks && i <= j 
+        s_idx_i = sorted_seq[index_i]
+        eligible_bitmask = UInt32(0)
+        special_bitmask = UInt32(0)
+        for m in a:warpsize()
+            s_idx_j = sorted_seq[j_0_tile + m]
+            eligible_bitmask = (eligible_bitmask << 1) | UInt32(eligible_matrix[s_idx_i, s_idx_j])
+            special_bitmask = (special_bitmask << 1) | UInt32(special_matrix[s_idx_i, s_idx_j])
+        end
+        compressed_eligible[laneid(), i, j] = eligible_bitmask
+        compressed_special[laneid(), i, j] = special_bitmask
+    end
 
-	if j == n_blocks && i < j
-		s_idx_i = sorted_seq[index_i]
-		eligible_bitmask = UInt32(0)
-		special_bitmask = UInt32(0)
-		for m in a:r
-			s_idx_j = sorted_seq[j_0_tile + m]
-			eligible_bitmask = (eligible_bitmask << 1) | UInt32(eligible_matrix[s_idx_i, s_idx_j])
-			special_bitmask = (special_bitmask << 1) | UInt32(special_matrix[s_idx_i, s_idx_j])
-		end
-		eligible_bitmask = (eligible_bitmask >> r) | (eligible_bitmask << (warpsize() - r))
-		special_bitmask = (special_bitmask >> r) | (special_bitmask << (warpsize() - r))
-		compressed_eligible[laneid(), i, j] = eligible_bitmask
-		compressed_special[laneid(), i, j] = special_bitmask
-	end
+    if j == n_blocks && i < j
+        s_idx_i = sorted_seq[index_i]
+        eligible_bitmask = UInt32(0)
+        special_bitmask = UInt32(0)
+        for m in a:r
+            s_idx_j = sorted_seq[j_0_tile + m]
+            eligible_bitmask = (eligible_bitmask << 1) | UInt32(eligible_matrix[s_idx_i, s_idx_j])
+            special_bitmask = (special_bitmask << 1) | UInt32(special_matrix[s_idx_i, s_idx_j])
+        end
+        eligible_bitmask = (eligible_bitmask >> r) | (eligible_bitmask << (warpsize() - r))
+        special_bitmask = (special_bitmask >> r) | (special_bitmask << (warpsize() - r))
+        compressed_eligible[laneid(), i, j] = eligible_bitmask
+        compressed_special[laneid(), i, j] = special_bitmask
+    end
 
-	if j == n_blocks && i == j && laneid() <= r
-		s_idx_i = sorted_seq[index_i]
-		eligible_bitmask = UInt32(0)
-		special_bitmask = UInt32(0)
-		for m in a:r
-			s_idx_j = sorted_seq[j_0_tile + m]
-			eligible_bitmask = (eligible_bitmask << 1) | UInt32(eligible_matrix[s_idx_i, s_idx_j])
-			special_bitmask = (special_bitmask << 1) | UInt32(special_matrix[s_idx_i, s_idx_j])
-		end
-		eligible_bitmask = (eligible_bitmask >> r) | (eligible_bitmask << (warpsize() - r))
-		special_bitmask = (special_bitmask >> r) | (special_bitmask << (warpsize() - r))
-		compressed_eligible[laneid(), i, j] = eligible_bitmask
-		compressed_special[laneid(), i, j] = special_bitmask
-	end
-	return nothing
+    if j == n_blocks && i == j && laneid() <= r
+        s_idx_i = sorted_seq[index_i]
+        eligible_bitmask = UInt32(0)
+        special_bitmask = UInt32(0)
+        for m in a:r
+            s_idx_j = sorted_seq[j_0_tile + m]
+            eligible_bitmask = (eligible_bitmask << 1) | UInt32(eligible_matrix[s_idx_i, s_idx_j])
+            special_bitmask = (special_bitmask << 1) | UInt32(special_matrix[s_idx_i, s_idx_j])
+        end
+        eligible_bitmask = (eligible_bitmask >> r) | (eligible_bitmask << (warpsize() - r))
+        special_bitmask = (special_bitmask >> r) | (special_bitmask << (warpsize() - r))
+        compressed_eligible[laneid(), i, j] = eligible_bitmask
+        compressed_special[laneid(), i, j] = special_bitmask
+    end
+    return nothing
 end
 
 
@@ -269,958 +269,958 @@ forces for the entire row in `WARPSIZE` steps. This is done such that some data 
 subsequent iteration of the force calculation in a row. If `a, b, ...` are different atoms and `1, 2, ...` are order in which each thread calculates
 the interatomic forces, then we can represent this scenario as (considering `WARPSIZE=8`):
 ```
-	× | i j k l m n o p
-	--------------------
-	a | 1 2 3 4 5 6 7 8
-	b | 8 1 2 3 4 5 6 7
-	c | 7 8 1 2 3 4 5 6
-	d | 6 7 8 1 2 3 4 5
-	e | 5 6 7 8 1 2 3 4
-	f | 4 5 6 7 8 1 2 3
-	g | 3 4 5 6 7 8 1 2
-	h | 2 3 4 5 6 7 8 1
+    × | i j k l m n o p
+    --------------------
+    a | 1 2 3 4 5 6 7 8
+    b | 8 1 2 3 4 5 6 7
+    c | 7 8 1 2 3 4 5 6
+    d | 6 7 8 1 2 3 4 5
+    e | 5 6 7 8 1 2 3 4
+    f | 4 5 6 7 8 1 2 3
+    g | 3 4 5 6 7 8 1 2
+    h | 2 3 4 5 6 7 8 1
 ```
 
 2. Cases j == n_blocks && i < n_blocks, i == j && i < n_blocks, i == n_blocks && j == n_blocks: In such cases, it is not possible to shuffle data generally
 so there is no need to order calculations for each thread diagonally and it is also a bit more complicated to do so.
 That's why the calculations are done in the following order:
 ```
-	× | i j k l m n
-	----------------
-	a | 1 2 3 4 5 6
-	b | 1 2 3 4 5 6
-	c | 1 2 3 4 5 6
-	d | 1 2 3 4 5 6
-	e | 1 2 3 4 5 6
-	f | 1 2 3 4 5 6
-	g | 1 2 3 4 5 6
-	h | 1 2 3 4 5 6
+    × | i j k l m n
+    ----------------
+    a | 1 2 3 4 5 6
+    b | 1 2 3 4 5 6
+    c | 1 2 3 4 5 6
+    d | 1 2 3 4 5 6
+    e | 1 2 3 4 5 6
+    f | 1 2 3 4 5 6
+    g | 1 2 3 4 5 6
+    h | 1 2 3 4 5 6
 ```
 =#
 
 function force_kernel!( 
-	sorted_seq,
-	forces_nounits, 
-	mins::AbstractArray{C}, 
-	maxs::AbstractArray{C},
-	coords, 
-	velocities,
-	atoms,
-	::Val{N}, 
-	r_cut, 
-	::Val{force_units},
-	inters_tuple,
-	boundary,
-	step_n,
-	special_compressed,
-	eligible_compressed,
-	::Val{T},
-	::Val{D}) where {N, C, force_units, T, D}
+    sorted_seq,
+    forces_nounits, 
+    mins::AbstractArray{C}, 
+    maxs::AbstractArray{C},
+    coords, 
+    velocities,
+    atoms,
+    ::Val{N}, 
+    r_cut, 
+    ::Val{force_units},
+    inters_tuple,
+    boundary,
+    step_n,
+    special_compressed,
+    eligible_compressed,
+    ::Val{T},
+    ::Val{D}) where {N, C, force_units, T, D}
 
-	a = Int32(1)
-	b = Int32(D)
-	n_blocks = Int32(ceil(N / 32))
-	i = blockIdx().x
-	j = blockIdx().y
-	i_0_tile = (i - a) * warpsize()
-	j_0_tile = (j - a) * warpsize()
-	index_i = i_0_tile + laneid()
-	index_j = j_0_tile + laneid()
-	force_smem = CuStaticSharedArray(T, (32, 3))
-	opposites_sum = CuStaticSharedArray(T, (32, 3))
-	r = Int32((N - 1) % 32 + 1)
-	@inbounds for k in a:b
-		force_smem[laneid(), k] = zero(T)
-		opposites_sum[laneid(), k] = zero(T)
-	end
+    a = Int32(1)
+    b = Int32(D)
+    n_blocks = Int32(ceil(N / 32))
+    i = blockIdx().x
+    j = blockIdx().y
+    i_0_tile = (i - a) * warpsize()
+    j_0_tile = (j - a) * warpsize()
+    index_i = i_0_tile + laneid()
+    index_j = j_0_tile + laneid()
+    force_smem = CuStaticSharedArray(T, (32, 3))
+    opposites_sum = CuStaticSharedArray(T, (32, 3))
+    r = Int32((N - 1) % 32 + 1)
+    @inbounds for k in a:b
+        force_smem[laneid(), k] = zero(T)
+        opposites_sum[laneid(), k] = zero(T)
+    end
 
-	# The code is organised in 4 mutually excluding parts
-	if j < n_blocks && i < j
-		d_block = zero(C)
-		dist_block = zero(C) * zero(C)
-		@inbounds for k in a:b	
-			d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-			dist_block += d_block * d_block	
-		end
-		if dist_block <= r_cut * r_cut
-			s_idx_i = sorted_seq[index_i]
-			coords_i = coords[s_idx_i] 
-			vel_i = velocities[s_idx_i] 
-			atoms_i = atoms[s_idx_i]
-			d_pb = zero(C)
-			dist_pb = zero(C) * zero(C)
-			@inbounds for k in a:b	
-				d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-				dist_pb += d_pb * d_pb
-			end
+    # The code is organised in 4 mutually excluding parts
+    if j < n_blocks && i < j
+        d_block = zero(C)
+        dist_block = zero(C) * zero(C)
+        @inbounds for k in a:b	
+            d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+            dist_block += d_block * d_block	
+        end
+        if dist_block <= r_cut * r_cut
+            s_idx_i = sorted_seq[index_i]
+            coords_i = coords[s_idx_i] 
+            vel_i = velocities[s_idx_i] 
+            atoms_i = atoms[s_idx_i]
+            d_pb = zero(C)
+            dist_pb = zero(C) * zero(C)
+            @inbounds for k in a:b	
+                d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+                dist_pb += d_pb * d_pb
+            end
 
-			Bool_excl = dist_pb <= r_cut * r_cut
-			s_idx_j = sorted_seq[index_j]
-			coords_j = coords[s_idx_j]
-			vel_j = velocities[s_idx_j] 
-			shuffle_idx = laneid()
-			atoms_j = atoms[s_idx_j]
-			atype_j = atoms_j.atom_type
-			aindex_j = atoms_j.index
-			amass_j = atoms_j.mass
-			acharge_j = atoms_j.charge
-			aσ_j = atoms_j.σ
-			aϵ_j = atoms_j.ϵ
-			eligible_bitmask = UInt32(0)
-			special_bitmask = UInt32(0)
-			eligible_bitmask = eligible_compressed[laneid(), i, j]
-			special_bitmask = special_compressed[laneid(), i, j]
+            Bool_excl = dist_pb <= r_cut * r_cut
+            s_idx_j = sorted_seq[index_j]
+            coords_j = coords[s_idx_j]
+            vel_j = velocities[s_idx_j] 
+            shuffle_idx = laneid()
+            atoms_j = atoms[s_idx_j]
+            atype_j = atoms_j.atom_type
+            aindex_j = atoms_j.index
+            amass_j = atoms_j.mass
+            acharge_j = atoms_j.charge
+            aσ_j = atoms_j.σ
+            aϵ_j = atoms_j.ϵ
+            eligible_bitmask = UInt32(0)
+            special_bitmask = UInt32(0)
+            eligible_bitmask = eligible_compressed[laneid(), i, j]
+            special_bitmask = special_compressed[laneid(), i, j]
 
-			# Shuffle
-			for m in a:warpsize()
-				sync_warp()
-				coords_j = CUDA.shfl_sync(0xFFFFFFFF, coords_j, laneid() + a, warpsize())
-				vel_j = CUDA.shfl_sync(0xFFFFFFFF, vel_j, laneid() + a, warpsize())
-				shuffle_idx = CUDA.shfl_sync(0xFFFFFFFF, shuffle_idx, laneid() + a, warpsize())
-				atype_j = CUDA.shfl_sync(0xFFFFFFFF, atype_j, laneid() + a, warpsize())
-				aindex_j = CUDA.shfl_sync(0xFFFFFFFF, aindex_j, laneid() + a, warpsize())
-				amass_j = CUDA.shfl_sync(0xFFFFFFFF, amass_j, laneid() + a, warpsize())
-				acharge_j = CUDA.shfl_sync(0xFFFFFFFF, acharge_j, laneid() + a, warpsize())
-				aσ_j = CUDA.shfl_sync(0xFFFFFFFF, aσ_j, laneid() + a, warpsize())
-				aϵ_j = CUDA.shfl_sync(0xFFFFFFFF, aϵ_j, laneid() + a, warpsize())
-				
-				atoms_j_shuffle = Atom(atype_j, aindex_j, amass_j, acharge_j, aσ_j, aϵ_j)
-				dr = vector(coords_j, coords_i, boundary)
-				r2 = sum(abs2, dr)
-				excl = (eligible_bitmask >> (warpsize() - shuffle_idx)) | (eligible_bitmask << shuffle_idx)
-				spec = (special_bitmask >> (warpsize() - shuffle_idx)) | (special_bitmask << shuffle_idx)
-				condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
- 				
-				f = condition ? sum_pairwise_forces(
-					inters_tuple,
-					atoms_i, atoms_j_shuffle,
-					Val(force_units),
-					(spec & 0x1) == true,
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{D, T})
+            # Shuffle
+            for m in a:warpsize()
+                sync_warp()
+                coords_j = CUDA.shfl_sync(0xFFFFFFFF, coords_j, laneid() + a, warpsize())
+                vel_j = CUDA.shfl_sync(0xFFFFFFFF, vel_j, laneid() + a, warpsize())
+                shuffle_idx = CUDA.shfl_sync(0xFFFFFFFF, shuffle_idx, laneid() + a, warpsize())
+                atype_j = CUDA.shfl_sync(0xFFFFFFFF, atype_j, laneid() + a, warpsize())
+                aindex_j = CUDA.shfl_sync(0xFFFFFFFF, aindex_j, laneid() + a, warpsize())
+                amass_j = CUDA.shfl_sync(0xFFFFFFFF, amass_j, laneid() + a, warpsize())
+                acharge_j = CUDA.shfl_sync(0xFFFFFFFF, acharge_j, laneid() + a, warpsize())
+                aσ_j = CUDA.shfl_sync(0xFFFFFFFF, aσ_j, laneid() + a, warpsize())
+                aϵ_j = CUDA.shfl_sync(0xFFFFFFFF, aϵ_j, laneid() + a, warpsize())
+                
+                atoms_j_shuffle = Atom(atype_j, aindex_j, amass_j, acharge_j, aσ_j, aϵ_j)
+                dr = vector(coords_j, coords_i, boundary)
+                r2 = sum(abs2, dr)
+                excl = (eligible_bitmask >> (warpsize() - shuffle_idx)) | (eligible_bitmask << shuffle_idx)
+                spec = (special_bitmask >> (warpsize() - shuffle_idx)) | (special_bitmask << shuffle_idx)
+                condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
+                 
+                f = condition ? sum_pairwise_forces(
+                    inters_tuple,
+                    atoms_i, atoms_j_shuffle,
+                    Val(force_units),
+                    (spec & 0x1) == true,
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{D, T})
 
-				@inbounds for k in a:b
-					force_smem[laneid(), k] += ustrip(f[k])
-					opposites_sum[shuffle_idx, k] -= ustrip(f[k])
-				end
-			end
-			sync_threads()
-			@inbounds for k in a:b
-				CUDA.atomic_add!(
-					pointer(forces_nounits, s_idx_i * b - (b - k)), 
-					-force_smem[laneid(), k]
-				) 
-				CUDA.atomic_add!(
-					pointer(forces_nounits, s_idx_j * b - (b - k)), 
-					-opposites_sum[laneid(), k]
-				) 
-			end
-		end
-	end
+                @inbounds for k in a:b
+                    force_smem[laneid(), k] += ustrip(f[k])
+                    opposites_sum[shuffle_idx, k] -= ustrip(f[k])
+                end
+            end
+            sync_threads()
+            @inbounds for k in a:b
+                CUDA.atomic_add!(
+                    pointer(forces_nounits, s_idx_i * b - (b - k)), 
+                    -force_smem[laneid(), k]
+                ) 
+                CUDA.atomic_add!(
+                    pointer(forces_nounits, s_idx_j * b - (b - k)), 
+                    -opposites_sum[laneid(), k]
+                ) 
+            end
+        end
+    end
 
-	if j == n_blocks && i < n_blocks
-		d_block = zero(C)
-		dist_block = zero(C) * zero(C)
-		@inbounds for k in a:b
-			d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-			dist_block += d_block * d_block	
-		end
+    if j == n_blocks && i < n_blocks
+        d_block = zero(C)
+        dist_block = zero(C) * zero(C)
+        @inbounds for k in a:b
+            d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+            dist_block += d_block * d_block	
+        end
 
-		if dist_block <= r_cut * r_cut 
-			s_idx_i = sorted_seq[index_i]
-			coords_i = coords[s_idx_i]
-			vel_i = velocities[s_idx_i]
-			atoms_i = atoms[s_idx_i]
-			d_pb = zero(C)
-			dist_pb = zero(C) * zero(C)			
-			@inbounds for k in a:b	
-				d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-				dist_pb += d_pb * d_pb
-			end
-			Bool_excl = dist_pb <= r_cut * r_cut
-			eligible_bitmask = UInt32(0)
-			special_bitmask = UInt32(0)
-			eligible_bitmask = eligible_compressed[laneid(), i, j]
-			special_bitmask = special_compressed[laneid(), i, j]
-			
-			for m in a:r
-				s_idx_j = sorted_seq[j_0_tile + m]
-				coords_j = coords[s_idx_j]
-				vel_j = velocities[s_idx_j]
-				atoms_j = atoms[s_idx_j]
-				dr = vector(coords_j, coords_i, boundary)
-				r2 = sum(abs2, dr)
-				excl = (eligible_bitmask >> (warpsize() - m)) | (eligible_bitmask << m)
-				spec = (special_bitmask >> (warpsize() - m)) | (special_bitmask << m)
-				condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
+        if dist_block <= r_cut * r_cut 
+            s_idx_i = sorted_seq[index_i]
+            coords_i = coords[s_idx_i]
+            vel_i = velocities[s_idx_i]
+            atoms_i = atoms[s_idx_i]
+            d_pb = zero(C)
+            dist_pb = zero(C) * zero(C)			
+            @inbounds for k in a:b	
+                d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+                dist_pb += d_pb * d_pb
+            end
+            Bool_excl = dist_pb <= r_cut * r_cut
+            eligible_bitmask = UInt32(0)
+            special_bitmask = UInt32(0)
+            eligible_bitmask = eligible_compressed[laneid(), i, j]
+            special_bitmask = special_compressed[laneid(), i, j]
+            
+            for m in a:r
+                s_idx_j = sorted_seq[j_0_tile + m]
+                coords_j = coords[s_idx_j]
+                vel_j = velocities[s_idx_j]
+                atoms_j = atoms[s_idx_j]
+                dr = vector(coords_j, coords_i, boundary)
+                r2 = sum(abs2, dr)
+                excl = (eligible_bitmask >> (warpsize() - m)) | (eligible_bitmask << m)
+                spec = (special_bitmask >> (warpsize() - m)) | (special_bitmask << m)
+                condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
 
-				f = condition ? sum_pairwise_forces(
-					inters_tuple,
-					atoms_i, atoms_j,
-					Val(force_units),
-					(spec & 0x1) == true,
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{D, T})
+                f = condition ? sum_pairwise_forces(
+                    inters_tuple,
+                    atoms_i, atoms_j,
+                    Val(force_units),
+                    (spec & 0x1) == true,
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{D, T})
 
-				@inbounds for k in a:b
-					force_smem[laneid(), k] += ustrip(f[k])
-					CUDA.atomic_add!(
-						pointer(forces_nounits, s_idx_j * b - (b - k)), 
-						ustrip(f[k])
-					)
-				end
-			end
+                @inbounds for k in a:b
+                    force_smem[laneid(), k] += ustrip(f[k])
+                    CUDA.atomic_add!(
+                        pointer(forces_nounits, s_idx_j * b - (b - k)), 
+                        ustrip(f[k])
+                    )
+                end
+            end
 
-			# Sum contributions of the r-block to the other standard blocks
-			@inbounds for k in a:b
-				CUDA.atomic_add!(
-					pointer(forces_nounits, s_idx_i * b - (b - k)), 
-					-force_smem[laneid(), k]
-				) 
-			end
-		end
-	end
+            # Sum contributions of the r-block to the other standard blocks
+            @inbounds for k in a:b
+                CUDA.atomic_add!(
+                    pointer(forces_nounits, s_idx_i * b - (b - k)), 
+                    -force_smem[laneid(), k]
+                ) 
+            end
+        end
+    end
 
-	if i == j && i < n_blocks
-		s_idx_i = sorted_seq[index_i]
-		coords_i = coords[s_idx_i]
-		vel_i = velocities[s_idx_i]
-		atoms_i = atoms[s_idx_i]
-		eligible_bitmask = UInt32(0)
-		special_bitmask = UInt32(0)
-		eligible_bitmask = eligible_compressed[laneid(), i, j]
-		special_bitmask = special_compressed[laneid(), i, j]
+    if i == j && i < n_blocks
+        s_idx_i = sorted_seq[index_i]
+        coords_i = coords[s_idx_i]
+        vel_i = velocities[s_idx_i]
+        atoms_i = atoms[s_idx_i]
+        eligible_bitmask = UInt32(0)
+        special_bitmask = UInt32(0)
+        eligible_bitmask = eligible_compressed[laneid(), i, j]
+        special_bitmask = special_compressed[laneid(), i, j]
 
-		for m in (laneid() + a) : warpsize()
-			s_idx_j = sorted_seq[j_0_tile + m]
-			coords_j = coords[s_idx_j]
-			vel_j = velocities[s_idx_j]
-			atoms_j = atoms[s_idx_j]
-			dr = vector(coords_j, coords_i, boundary)
-			r2 = sum(abs2, dr)
-			excl = (eligible_bitmask >> (warpsize() - m)) | (eligible_bitmask << m)
-			spec = (special_bitmask >> (warpsize() - m)) | (special_bitmask << m)
-			condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
+        for m in (laneid() + a) : warpsize()
+            s_idx_j = sorted_seq[j_0_tile + m]
+            coords_j = coords[s_idx_j]
+            vel_j = velocities[s_idx_j]
+            atoms_j = atoms[s_idx_j]
+            dr = vector(coords_j, coords_i, boundary)
+            r2 = sum(abs2, dr)
+            excl = (eligible_bitmask >> (warpsize() - m)) | (eligible_bitmask << m)
+            spec = (special_bitmask >> (warpsize() - m)) | (special_bitmask << m)
+            condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
 
-			f = condition ? sum_pairwise_forces(
-				inters_tuple,
-				atoms_i, atoms_j,
-				Val(force_units),
-				(spec & 0x1) == true,
-				coords_i, coords_j,
-				boundary,
-				vel_i, vel_j,
-				step_n) : zero(SVector{D, T})
-			
-			@inbounds for k in a:b
-				force_smem[laneid(), k] += ustrip(f[k])
-				opposites_sum[m, k] -= ustrip(f[k])
-			end
-		end	
+            f = condition ? sum_pairwise_forces(
+                inters_tuple,
+                atoms_i, atoms_j,
+                Val(force_units),
+                (spec & 0x1) == true,
+                coords_i, coords_j,
+                boundary,
+                vel_i, vel_j,
+                step_n) : zero(SVector{D, T})
+            
+            @inbounds for k in a:b
+                force_smem[laneid(), k] += ustrip(f[k])
+                opposites_sum[m, k] -= ustrip(f[k])
+            end
+        end	
 
-		@inbounds for k in a:b
-			# In this case i == j, so we can call atomic_add! only once
-			CUDA.atomic_add!(
-				pointer(forces_nounits, s_idx_i * b - (b - k)), 
-				-force_smem[laneid(), k] - opposites_sum[laneid(), k]
-			) 
-		end
-	end
+        @inbounds for k in a:b
+            # In this case i == j, so we can call atomic_add! only once
+            CUDA.atomic_add!(
+                pointer(forces_nounits, s_idx_i * b - (b - k)), 
+                -force_smem[laneid(), k] - opposites_sum[laneid(), k]
+            ) 
+        end
+    end
 
-	if i == n_blocks && j == n_blocks
-		if laneid() <= r
-			s_idx_i = sorted_seq[index_i]
-			coords_i = coords[s_idx_i]
-			vel_i = velocities[s_idx_i]
-			atoms_i = atoms[s_idx_i]
-			eligible_bitmask = UInt32(0)
-			special_bitmask = UInt32(0)
-			eligible_bitmask = eligible_compressed[laneid(), i, j]
-			special_bitmask = special_compressed[laneid(), i, j]
+    if i == n_blocks && j == n_blocks
+        if laneid() <= r
+            s_idx_i = sorted_seq[index_i]
+            coords_i = coords[s_idx_i]
+            vel_i = velocities[s_idx_i]
+            atoms_i = atoms[s_idx_i]
+            eligible_bitmask = UInt32(0)
+            special_bitmask = UInt32(0)
+            eligible_bitmask = eligible_compressed[laneid(), i, j]
+            special_bitmask = special_compressed[laneid(), i, j]
 
-			for m in (laneid() + a) : r
-				s_idx_j = sorted_seq[j_0_tile + m]
-				coords_j = coords[s_idx_j]
-				vel_j = velocities[s_idx_j]
-				atoms_j = atoms[s_idx_j]
-				dr = vector(coords_j, coords_i, boundary)
-				r2 = sum(abs2, dr)
-				excl = (eligible_bitmask >> (warpsize() - m)) | (eligible_bitmask << m)
-				spec = (special_bitmask >> (warpsize() - m)) | (special_bitmask << m)
-				condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
-				
-				f = condition ? sum_pairwise_forces(
-					inters_tuple,
-					atoms_i, atoms_j,
-					Val(force_units),
-					(spec & 0x1) == true,
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{D, T})
+            for m in (laneid() + a) : r
+                s_idx_j = sorted_seq[j_0_tile + m]
+                coords_j = coords[s_idx_j]
+                vel_j = velocities[s_idx_j]
+                atoms_j = atoms[s_idx_j]
+                dr = vector(coords_j, coords_i, boundary)
+                r2 = sum(abs2, dr)
+                excl = (eligible_bitmask >> (warpsize() - m)) | (eligible_bitmask << m)
+                spec = (special_bitmask >> (warpsize() - m)) | (special_bitmask << m)
+                condition = (excl & 0x1) == true && r2 <= r_cut * r_cut
+                
+                f = condition ? sum_pairwise_forces(
+                    inters_tuple,
+                    atoms_i, atoms_j,
+                    Val(force_units),
+                    (spec & 0x1) == true,
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{D, T})
 
-				@inbounds for k in a:b
-					force_smem[laneid(), k] += ustrip(f[k])
-					opposites_sum[m, k] -= ustrip(f[k])
-				end
-			end
-			@inbounds for k in a:b
-				CUDA.atomic_add!(
-					pointer(forces_nounits, s_idx_i * b - (b - k)), 
-					-force_smem[laneid(), k] - opposites_sum[laneid(), k]
-				) 
-			end
-		end
-	end
+                @inbounds for k in a:b
+                    force_smem[laneid(), k] += ustrip(f[k])
+                    opposites_sum[m, k] -= ustrip(f[k])
+                end
+            end
+            @inbounds for k in a:b
+                CUDA.atomic_add!(
+                    pointer(forces_nounits, s_idx_i * b - (b - k)), 
+                    -force_smem[laneid(), k] - opposites_sum[laneid(), k]
+                ) 
+            end
+        end
+    end
 
-	return nothing
+    return nothing
 end
 
 
 function energy_kernel!( 
-	sorted_seq,
-	energy_nounits, 
-	mins::AbstractArray{C}, 
-	maxs::AbstractArray{C}, 
-	coords, 
-	velocities,
-	atoms,
-	::Val{N}, 
-	r_cut, 
-	::Val{energy_units},
-	inters_tuple,
-	boundary,
-	step_n, 
-	special_matrix,
-	eligible_matrix,
-	::Val{T},
-	::Val{D}) where {N, C, energy_units, T, D}
+    sorted_seq,
+    energy_nounits, 
+    mins::AbstractArray{C}, 
+    maxs::AbstractArray{C}, 
+    coords, 
+    velocities,
+    atoms,
+    ::Val{N}, 
+    r_cut, 
+    ::Val{energy_units},
+    inters_tuple,
+    boundary,
+    step_n, 
+    special_matrix,
+    eligible_matrix,
+    ::Val{T},
+    ::Val{D}) where {N, C, energy_units, T, D}
 
-	a = Int32(1)
-	b = Int32(D)
-	n_blocks = Int32(ceil(N / 32))
-	r = Int32((N - 1) % 32 + 1)
-	i = blockIdx().x
-	j = blockIdx().y
-	i_0_tile = (i - 1) * warpsize()
-	j_0_tile = (j - 1) * warpsize()
-	index_i = i_0_tile + laneid()
-	index_j = j_0_tile + laneid()
-	E_smem = CuStaticSharedArray(T, 32)
-	E_smem[laneid()] = zero(T)
-	eligible = CuStaticSharedArray(Bool, (32, 32))
-	special = CuStaticSharedArray(Bool, (32, 32))
+    a = Int32(1)
+    b = Int32(D)
+    n_blocks = Int32(ceil(N / 32))
+    r = Int32((N - 1) % 32 + 1)
+    i = blockIdx().x
+    j = blockIdx().y
+    i_0_tile = (i - 1) * warpsize()
+    j_0_tile = (j - 1) * warpsize()
+    index_i = i_0_tile + laneid()
+    index_j = j_0_tile + laneid()
+    E_smem = CuStaticSharedArray(T, 32)
+    E_smem[laneid()] = zero(T)
+    eligible = CuStaticSharedArray(Bool, (32, 32))
+    special = CuStaticSharedArray(Bool, (32, 32))
 
-	# The code is organised in 4 mutually excluding parts
-	if j < n_blocks && i < j
-		d_block = zero(C)
-		dist_block = zero(C) * zero(C)
-		@inbounds for k in a:b	
-			d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-			dist_block += d_block * d_block	
-		end
-		if dist_block <= r_cut * r_cut
-			s_idx_i = sorted_seq[index_i]
-			coords_i = coords[s_idx_i] 
-			vel_i = velocities[s_idx_i]
-			atoms_i = atoms[s_idx_i]
-			d_pb = zero(C)
-			dist_pb = zero(C) * zero(C)
-			@inbounds for k in a:b	
-				d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-				dist_pb += d_pb * d_pb
-			end
-			Bool_excl = dist_pb <= r_cut * r_cut
-			s_idx_j = sorted_seq[index_j]
-			coords_j = coords[s_idx_j]
-			vel_j = velocities[s_idx_j]
-			shuffle_idx = laneid()
-			atoms_j = atoms[s_idx_j]
-			atype_j = atoms_j.atom_type
-			aindex_j = atoms_j.index
-			amass_j = atoms_j.mass
-			acharge_j = atoms_j.charge
-			aσ_j = atoms_j.σ
-			aϵ_j = atoms_j.ϵ
-			@inbounds for m in a:warpsize()
-				eligible[laneid(), m] = eligible_matrix[s_idx_i, sorted_seq[j_0_tile + m]]
-				special[laneid(), m] = special_matrix[s_idx_i, sorted_seq[j_0_tile + m]]
-			end
+    # The code is organised in 4 mutually excluding parts
+    if j < n_blocks && i < j
+        d_block = zero(C)
+        dist_block = zero(C) * zero(C)
+        @inbounds for k in a:b	
+            d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+            dist_block += d_block * d_block	
+        end
+        if dist_block <= r_cut * r_cut
+            s_idx_i = sorted_seq[index_i]
+            coords_i = coords[s_idx_i] 
+            vel_i = velocities[s_idx_i]
+            atoms_i = atoms[s_idx_i]
+            d_pb = zero(C)
+            dist_pb = zero(C) * zero(C)
+            @inbounds for k in a:b	
+                d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+                dist_pb += d_pb * d_pb
+            end
+            Bool_excl = dist_pb <= r_cut * r_cut
+            s_idx_j = sorted_seq[index_j]
+            coords_j = coords[s_idx_j]
+            vel_j = velocities[s_idx_j]
+            shuffle_idx = laneid()
+            atoms_j = atoms[s_idx_j]
+            atype_j = atoms_j.atom_type
+            aindex_j = atoms_j.index
+            amass_j = atoms_j.mass
+            acharge_j = atoms_j.charge
+            aσ_j = atoms_j.σ
+            aϵ_j = atoms_j.ϵ
+            @inbounds for m in a:warpsize()
+                eligible[laneid(), m] = eligible_matrix[s_idx_i, sorted_seq[j_0_tile + m]]
+                special[laneid(), m] = special_matrix[s_idx_i, sorted_seq[j_0_tile + m]]
+            end
 
-			# Shuffle
-			for m in a:warpsize()
-				sync_warp()
-				coords_j = CUDA.shfl_sync(0xFFFFFFFF, coords_j, laneid() + a, warpsize())
-				vel_j = CUDA.shfl_sync(0xFFFFFFFF, vel_j, laneid() + a, warpsize())
-				s_idx_j = CUDA.shfl_sync(0xFFFFFFFF, s_idx_j, laneid() + a, warpsize())
-				shuffle_idx = CUDA.shfl_sync(0xFFFFFFFF, shuffle_idx, laneid() + a, warpsize())
-				atype_j = CUDA.shfl_sync(0xFFFFFFFF, atype_j, laneid() + a, warpsize())
-				aindex_j = CUDA.shfl_sync(0xFFFFFFFF, aindex_j, laneid() + a, warpsize())
-				amass_j = CUDA.shfl_sync(0xFFFFFFFF, amass_j, laneid() + a, warpsize())
-				acharge_j = CUDA.shfl_sync(0xFFFFFFFF, acharge_j, laneid() + a, warpsize())
-				aσ_j = CUDA.shfl_sync(0xFFFFFFFF, aσ_j, laneid() + a, warpsize())
-				aϵ_j = CUDA.shfl_sync(0xFFFFFFFF, aϵ_j, laneid() + a, warpsize())
-				
-				atoms_j_shuffle = Atom(atype_j, aindex_j, amass_j, acharge_j, aσ_j, aϵ_j)
-				dr = vector(coords_j, coords_i, boundary)
-				r2 = sum(abs2, dr)
-				condition = eligible[laneid(), shuffle_idx] && Bool_excl && r2 <= r_cut * r_cut
+            # Shuffle
+            for m in a:warpsize()
+                sync_warp()
+                coords_j = CUDA.shfl_sync(0xFFFFFFFF, coords_j, laneid() + a, warpsize())
+                vel_j = CUDA.shfl_sync(0xFFFFFFFF, vel_j, laneid() + a, warpsize())
+                s_idx_j = CUDA.shfl_sync(0xFFFFFFFF, s_idx_j, laneid() + a, warpsize())
+                shuffle_idx = CUDA.shfl_sync(0xFFFFFFFF, shuffle_idx, laneid() + a, warpsize())
+                atype_j = CUDA.shfl_sync(0xFFFFFFFF, atype_j, laneid() + a, warpsize())
+                aindex_j = CUDA.shfl_sync(0xFFFFFFFF, aindex_j, laneid() + a, warpsize())
+                amass_j = CUDA.shfl_sync(0xFFFFFFFF, amass_j, laneid() + a, warpsize())
+                acharge_j = CUDA.shfl_sync(0xFFFFFFFF, acharge_j, laneid() + a, warpsize())
+                aσ_j = CUDA.shfl_sync(0xFFFFFFFF, aσ_j, laneid() + a, warpsize())
+                aϵ_j = CUDA.shfl_sync(0xFFFFFFFF, aϵ_j, laneid() + a, warpsize())
+                
+                atoms_j_shuffle = Atom(atype_j, aindex_j, amass_j, acharge_j, aσ_j, aϵ_j)
+                dr = vector(coords_j, coords_i, boundary)
+                r2 = sum(abs2, dr)
+                condition = eligible[laneid(), shuffle_idx] && Bool_excl && r2 <= r_cut * r_cut
 
-				pe = condition ? sum_pairwise_potentials(
-					inters_tuple,
-					atoms_i, atoms_j_shuffle,
-					Val(energy_units),
-					special[laneid(), shuffle_idx],
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{1, T})
+                pe = condition ? sum_pairwise_potentials(
+                    inters_tuple,
+                    atoms_i, atoms_j_shuffle,
+                    Val(energy_units),
+                    special[laneid(), shuffle_idx],
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{1, T})
 
-				E_smem[laneid()] += ustrip(pe[1])
-			end
-		end
-	end
+                E_smem[laneid()] += ustrip(pe[1])
+            end
+        end
+    end
 
-	if j == n_blocks && i < n_blocks
-		d_block = zero(C)
-		dist_block = zero(C) * zero(C)
-		@inbounds for k in a:b
-			d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-			dist_block += d_block * d_block	
-		end
-		if dist_block <= r_cut * r_cut 
-			s_idx_i = sorted_seq[index_i]
-			coords_i = coords[s_idx_i]
-			vel_i = velocities[s_idx_i]
-			atoms_i = atoms[s_idx_i]
-			d_pb = zero(C)
-			dist_pb = zero(C) * zero(C)			
-			@inbounds for k in a:b	
-				d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
-				dist_pb += d_pb * d_pb
-			end
-			Bool_excl = dist_pb <= r_cut * r_cut
-			@inbounds for m in a:r
-				s_idx_j = sorted_seq[j_0_tile + m]
-				eligible[laneid(), m] = eligible_matrix[s_idx_i, s_idx_j]
-				special[laneid(), m] = special_matrix[s_idx_i, s_idx_j]
-			end
-			
-			for m in a:r
-				s_idx_j = sorted_seq[j_0_tile + m]
-				coords_j = coords[s_idx_j]
-				vel_j = velocities[s_idx_j]
-				atoms_j = atoms[s_idx_j]
-				dr = vector(coords_j, coords_i, boundary)
-				r2 = sum(abs2, dr)
-				condition = eligible[laneid(), m] && Bool_excl && r2 <= r_cut * r_cut
+    if j == n_blocks && i < n_blocks
+        d_block = zero(C)
+        dist_block = zero(C) * zero(C)
+        @inbounds for k in a:b
+            d_block = boxes_dist(mins[i, k], maxs[i, k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+            dist_block += d_block * d_block	
+        end
+        if dist_block <= r_cut * r_cut 
+            s_idx_i = sorted_seq[index_i]
+            coords_i = coords[s_idx_i]
+            vel_i = velocities[s_idx_i]
+            atoms_i = atoms[s_idx_i]
+            d_pb = zero(C)
+            dist_pb = zero(C) * zero(C)			
+            @inbounds for k in a:b	
+                d_pb = boxes_dist(coords_i[k], coords_i[k], mins[j, k], maxs[j, k], boundary.side_lengths[k])
+                dist_pb += d_pb * d_pb
+            end
+            Bool_excl = dist_pb <= r_cut * r_cut
+            @inbounds for m in a:r
+                s_idx_j = sorted_seq[j_0_tile + m]
+                eligible[laneid(), m] = eligible_matrix[s_idx_i, s_idx_j]
+                special[laneid(), m] = special_matrix[s_idx_i, s_idx_j]
+            end
+            
+            for m in a:r
+                s_idx_j = sorted_seq[j_0_tile + m]
+                coords_j = coords[s_idx_j]
+                vel_j = velocities[s_idx_j]
+                atoms_j = atoms[s_idx_j]
+                dr = vector(coords_j, coords_i, boundary)
+                r2 = sum(abs2, dr)
+                condition = eligible[laneid(), m] && Bool_excl && r2 <= r_cut * r_cut
 
-				pe = condition ? sum_pairwise_potentials(
-					inters_tuple,
-					atoms_i, atoms_j,
-					Val(energy_units),
-					special[laneid(), m],
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{1, T})
+                pe = condition ? sum_pairwise_potentials(
+                    inters_tuple,
+                    atoms_i, atoms_j,
+                    Val(energy_units),
+                    special[laneid(), m],
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{1, T})
 
-				E_smem[laneid()] += ustrip(pe[1])
-			end
-		end
-	end
+                E_smem[laneid()] += ustrip(pe[1])
+            end
+        end
+    end
 
-	if i == j && i < n_blocks
-		s_idx_i = sorted_seq[index_i]
-		coords_i = coords[s_idx_i]
-		vel_i = velocities[s_idx_i]
-		atoms_i = atoms[s_idx_i]
-		@inbounds for m in a:warpsize()
-			s_idx_j = sorted_seq[j_0_tile + m]
-			eligible[laneid(), m] = eligible_matrix[s_idx_i, s_idx_j]
-			special[laneid(), m] = special_matrix[s_idx_i, s_idx_j]
-		end
-		@inbounds for m in (laneid() + a) : warpsize()
-			s_idx_j = sorted_seq[j_0_tile + m]
-			coords_j = coords[s_idx_j]
-			vel_j = velocities[s_idx_j]
-			atoms_j = atoms[s_idx_j]
-			dr = vector(coords_j, coords_i, boundary)
-			r2 = sum(abs2, dr)
-			condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
+    if i == j && i < n_blocks
+        s_idx_i = sorted_seq[index_i]
+        coords_i = coords[s_idx_i]
+        vel_i = velocities[s_idx_i]
+        atoms_i = atoms[s_idx_i]
+        @inbounds for m in a:warpsize()
+            s_idx_j = sorted_seq[j_0_tile + m]
+            eligible[laneid(), m] = eligible_matrix[s_idx_i, s_idx_j]
+            special[laneid(), m] = special_matrix[s_idx_i, s_idx_j]
+        end
+        @inbounds for m in (laneid() + a) : warpsize()
+            s_idx_j = sorted_seq[j_0_tile + m]
+            coords_j = coords[s_idx_j]
+            vel_j = velocities[s_idx_j]
+            atoms_j = atoms[s_idx_j]
+            dr = vector(coords_j, coords_i, boundary)
+            r2 = sum(abs2, dr)
+            condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
 
-			pe = condition ? sum_pairwise_potentials(
-					inters_tuple,
-					atoms_i, atoms_j,
-					Val(energy_units),
-					special[laneid(), m],
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{1, T})
+            pe = condition ? sum_pairwise_potentials(
+                    inters_tuple,
+                    atoms_i, atoms_j,
+                    Val(energy_units),
+                    special[laneid(), m],
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{1, T})
 
-			E_smem[laneid()] += ustrip(pe[1])
-		end	
-	end
+            E_smem[laneid()] += ustrip(pe[1])
+        end	
+    end
 
-	if i == n_blocks && j == n_blocks
-		if laneid() <= r
-			s_idx_i = sorted_seq[index_i]
-			coords_i = coords[s_idx_i]
-			vel_i = velocities[s_idx_i]
-			atoms_i = atoms[s_idx_i]
-			@inbounds for m in a:r
-				s_idx_j = sorted_seq[j_0_tile + m]
-				eligible[laneid(), m] = eligible_matrix[s_idx_i, s_idx_j]
-				special[laneid(), m] = special_matrix[s_idx_i, s_idx_j]
-			end
+    if i == n_blocks && j == n_blocks
+        if laneid() <= r
+            s_idx_i = sorted_seq[index_i]
+            coords_i = coords[s_idx_i]
+            vel_i = velocities[s_idx_i]
+            atoms_i = atoms[s_idx_i]
+            @inbounds for m in a:r
+                s_idx_j = sorted_seq[j_0_tile + m]
+                eligible[laneid(), m] = eligible_matrix[s_idx_i, s_idx_j]
+                special[laneid(), m] = special_matrix[s_idx_i, s_idx_j]
+            end
 
-			@inbounds for m in (laneid() + a) : r
-				s_idx_j = sorted_seq[j_0_tile + m]
-				coords_j = coords[s_idx_j]
-				vel_j = velocities[s_idx_j]
-				atoms_j = atoms[s_idx_j]
-				dr = vector(coords_j, coords_i, boundary)
-				r2 = sum(abs2, dr)
-				condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
-				
-				pe = condition ? sum_pairwise_potentials(
-					inters_tuple,
-					atoms_i, atoms_j,
-					Val(energy_units),
-					special[laneid(), m],
-					coords_i, coords_j,
-					boundary,
-					vel_i, vel_j,
-					step_n) : zero(SVector{1, T})
+            @inbounds for m in (laneid() + a) : r
+                s_idx_j = sorted_seq[j_0_tile + m]
+                coords_j = coords[s_idx_j]
+                vel_j = velocities[s_idx_j]
+                atoms_j = atoms[s_idx_j]
+                dr = vector(coords_j, coords_i, boundary)
+                r2 = sum(abs2, dr)
+                condition = eligible[laneid(), m] && r2 <= r_cut * r_cut
+                
+                pe = condition ? sum_pairwise_potentials(
+                    inters_tuple,
+                    atoms_i, atoms_j,
+                    Val(energy_units),
+                    special[laneid(), m],
+                    coords_i, coords_j,
+                    boundary,
+                    vel_i, vel_j,
+                    step_n) : zero(SVector{1, T})
 
-				E_smem[laneid()] += ustrip(pe[1])
-			end
-		end
-	end
+                E_smem[laneid()] += ustrip(pe[1])
+            end
+        end
+    end
 
-	if threadIdx().x == a
-		sum_E = zero(T)
-		for k in a:warpsize()
-			sum_E += E_smem[k]
-		end
-		CUDA.atomic_add!(pointer(energy_nounits), sum_E)
-	end
-	return nothing
+    if threadIdx().x == a
+        sum_E = zero(T)
+        for k in a:warpsize()
+            sum_E += E_smem[k]
+        end
+        CUDA.atomic_add!(pointer(energy_nounits), sum_E)
+    end
+    return nothing
 end
 
 
 
 function pairwise_force_kernel_nonl!(forces::AbstractArray{T}, coords_var, velocities_var,
-						atoms_var, boundary, inters, step_n, ::Val{D}, ::Val{F}) where {T, D, F}
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	n_atoms = length(atoms)
+                        atoms_var, boundary, inters, step_n, ::Val{D}, ::Val{F}) where {T, D, F}
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    n_atoms = length(atoms)
 
-	tidx = threadIdx().x
-	i_0_tile = (blockIdx().x - 1) * warpsize()
-	j_0_block = (blockIdx().y - 1) * blockDim().x
-	warpidx = cld(tidx, warpsize())
-	j_0_tile = j_0_block + (warpidx - 1) * warpsize()
-	i = i_0_tile + laneid()
+    tidx = threadIdx().x
+    i_0_tile = (blockIdx().x - 1) * warpsize()
+    j_0_block = (blockIdx().y - 1) * blockDim().x
+    warpidx = cld(tidx, warpsize())
+    j_0_tile = j_0_block + (warpidx - 1) * warpsize()
+    i = i_0_tile + laneid()
 
-	forces_shmem = CuStaticSharedArray(T, (3, 1024))
-	@inbounds for dim in 1:3
-		forces_shmem[dim, tidx] = zero(T)
-	end
+    forces_shmem = CuStaticSharedArray(T, (3, 1024))
+    @inbounds for dim in 1:3
+        forces_shmem[dim, tidx] = zero(T)
+    end
 
-	if i_0_tile + warpsize() > n_atoms || j_0_tile + warpsize() > n_atoms
-		@inbounds if i <= n_atoms
-			njs = min(warpsize(), n_atoms - j_0_tile)
-			atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
-			for del_j in 1:njs
-				j = j_0_tile + del_j
-				if i != j
-					atom_j, coord_j, vel_j = atoms[j], coords[j], velocities[j]
-					f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
-											boundary, vel_i, vel_j, step_n)
-					for dim in 1:D
-						forces_shmem[dim, tidx] += -ustrip(f[dim])
-					end
-				end
-			end
+    if i_0_tile + warpsize() > n_atoms || j_0_tile + warpsize() > n_atoms
+        @inbounds if i <= n_atoms
+            njs = min(warpsize(), n_atoms - j_0_tile)
+            atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
+            for del_j in 1:njs
+                j = j_0_tile + del_j
+                if i != j
+                    atom_j, coord_j, vel_j = atoms[j], coords[j], velocities[j]
+                    f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
+                                            boundary, vel_i, vel_j, step_n)
+                    for dim in 1:D
+                        forces_shmem[dim, tidx] += -ustrip(f[dim])
+                    end
+                end
+            end
 
-			for dim in 1:D
-				Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
-			end
-		end
-	else
-		j = j_0_tile + laneid()
-		tilesteps = warpsize()
-		if i_0_tile == j_0_tile  # To not compute i-i forces
-			j = j_0_tile + laneid() % warpsize() + 1
-			tilesteps -= 1
-		end
+            for dim in 1:D
+                Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
+            end
+        end
+    else
+        j = j_0_tile + laneid()
+        tilesteps = warpsize()
+        if i_0_tile == j_0_tile  # To not compute i-i forces
+            j = j_0_tile + laneid() % warpsize() + 1
+            tilesteps -= 1
+        end
 
-		atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
-		coord_j, vel_j = coords[j], velocities[j]
-		@inbounds for _ in 1:tilesteps
-			sync_warp()
-			atom_j = atoms[j]
-			f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
-									boundary, vel_i, vel_j, step_n)
-			for dim in 1:D
-				forces_shmem[dim, tidx] += -ustrip(f[dim])
-			end
-			@shfl_multiple_sync(FULL_MASK, laneid() + 1, warpsize(), j, coord_j)
-		end
+        atom_i, coord_i, vel_i = atoms[i], coords[i], velocities[i]
+        coord_j, vel_j = coords[j], velocities[j]
+        @inbounds for _ in 1:tilesteps
+            sync_warp()
+            atom_j = atoms[j]
+            f = sum_pairwise_forces(inters, atom_i, atom_j, Val(F), false, coord_i, coord_j,
+                                    boundary, vel_i, vel_j, step_n)
+            for dim in 1:D
+                forces_shmem[dim, tidx] += -ustrip(f[dim])
+            end
+            @shfl_multiple_sync(FULL_MASK, laneid() + 1, warpsize(), j, coord_j)
+        end
 
-		@inbounds for dim in 1:D
-			Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
-		end
-	end
+        @inbounds for dim in 1:D
+            Atomix.@atomic :monotonic forces[dim, i] += forces_shmem[dim, tidx]
+        end
+    end
 
-	return nothing
+    return nothing
 end
 
 function pairwise_pe_kernel!(energy, coords_var, velocities_var, atoms_var, boundary, inters,
-							 neighbors_var, step_n, ::Val{E}) where E
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	neighbors = CUDA.Const(neighbors_var)
+                             neighbors_var, step_n, ::Val{E}) where E
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    neighbors = CUDA.Const(neighbors_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(neighbors)
-		i, j, special = neighbors[inter_i]
-		coord_i, coord_j, vel_i, vel_j = coords[i], coords[j], velocities[i], velocities[j]
-		dr = vector(coord_i, coord_j, boundary)
-		pe = potential_energy_gpu(inters[1], dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
-								  boundary, vel_i, vel_j, step_n)
-		for inter in inters[2:end]
-			pe += potential_energy_gpu(inter, dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
-									   boundary, vel_i, vel_j, step_n)
-		end
-		if unit(pe) != E
-			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-		end
-		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-	end
-	return nothing
+    @inbounds if inter_i <= length(neighbors)
+        i, j, special = neighbors[inter_i]
+        coord_i, coord_j, vel_i, vel_j = coords[i], coords[j], velocities[i], velocities[j]
+        dr = vector(coord_i, coord_j, boundary)
+        pe = potential_energy_gpu(inters[1], dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
+                                  boundary, vel_i, vel_j, step_n)
+        for inter in inters[2:end]
+            pe += potential_energy_gpu(inter, dr, atoms[i], atoms[j], E, special, coord_i, coord_j,
+                                       boundary, vel_i, vel_j, step_n)
+        end
+        if unit(pe) != E
+            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+        end
+        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+    end
+    return nothing
 end
 
 @inline function sum_pairwise_forces(inters, atom_i, atom_j, ::Val{F}, special, coord_i, coord_j,
-									 boundary, vel_i, vel_j, step_n) where F
-	dr = vector(coord_i, coord_j, boundary)
-	f_tuple = ntuple(length(inters)) do inter_type_i
-		force_gpu(inters[inter_type_i], dr, atom_i, atom_j, F, special, coord_i, coord_j, boundary,
-				  vel_i, vel_j, step_n)
-	end
-	f = sum(f_tuple)
-	if unit(f[1]) != F
-		# This triggers an error but it isn't printed
-		# See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
-		#   for how to throw a more meaningful error
-		error("wrong force unit returned, was expecting $F but got $(unit(f[1]))")
-	end
-	return f
+                                     boundary, vel_i, vel_j, step_n) where F
+    dr = vector(coord_i, coord_j, boundary)
+    f_tuple = ntuple(length(inters)) do inter_type_i
+        force_gpu(inters[inter_type_i], dr, atom_i, atom_j, F, special, coord_i, coord_j, boundary,
+                  vel_i, vel_j, step_n)
+    end
+    f = sum(f_tuple)
+    if unit(f[1]) != F
+        # This triggers an error but it isn't printed
+        # See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
+        #   for how to throw a more meaningful error
+        error("wrong force unit returned, was expecting $F but got $(unit(f[1]))")
+    end
+    return f
 end
 
 @inline function sum_pairwise_potentials(inters, atom_i, atom_j, ::Val{E}, special, coord_i, coord_j,
-									 boundary, vel_i, vel_j, step_n) where E
-	dr = vector(coord_i, coord_j, boundary)
+                                     boundary, vel_i, vel_j, step_n) where E
+    dr = vector(coord_i, coord_j, boundary)
 
-	pe_tuple = ntuple(length(inters)) do inter_type_i
-		SVector(potential_energy_gpu(inters[inter_type_i], dr, atom_i, atom_j, E, special, coord_i, coord_j, boundary,
-				  vel_i, vel_j, step_n))
-				  # SVector was required to avoid a GPU error occurring with scalars (like the quantity returned by potential_energy_gpu) 
-	end
-	pe = sum(pe_tuple)
-	if unit(pe[1]) != E
-		# This triggers an error but it isn't printed
-		# See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
-		#   for how to throw a more meaningful error
-		error("wrong force unit returned, was expecting $E but got $(unit(pe[1]))")
-	end
-	return pe
+    pe_tuple = ntuple(length(inters)) do inter_type_i
+        SVector(potential_energy_gpu(inters[inter_type_i], dr, atom_i, atom_j, E, special, coord_i, coord_j, boundary,
+                  vel_i, vel_j, step_n))
+                  # SVector was required to avoid a GPU error occurring with scalars (like the quantity returned by potential_energy_gpu) 
+    end
+    pe = sum(pe_tuple)
+    if unit(pe[1]) != E
+        # This triggers an error but it isn't printed
+        # See https://discourse.julialang.org/t/error-handling-in-cuda-kernels/79692
+        #   for how to throw a more meaningful error
+        error("wrong force unit returned, was expecting $E but got $(unit(pe[1]))")
+    end
+    return pe
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList1Atoms, coords::AbstractArray{SVector{D, C}},
-							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_1_atoms_kernel!(fs_mat,
-			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.inters,
-			Val(D), Val(force_units))
-	return fs_mat
+                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_1_atoms_kernel!(fs_mat,
+            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.inters,
+            Val(D), Val(force_units))
+    return fs_mat
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList2Atoms, coords::AbstractArray{SVector{D, C}},
-							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_2_atoms_kernel!(fs_mat,
-			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
-			inter_list.inters, Val(D), Val(force_units))
-	return fs_mat
+                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_2_atoms_kernel!(fs_mat,
+            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
+            inter_list.inters, Val(D), Val(force_units))
+    return fs_mat
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList3Atoms, coords::AbstractArray{SVector{D, C}},
-							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_3_atoms_kernel!(fs_mat,
-			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
-			inter_list.ks, inter_list.inters, Val(D), Val(force_units))
-	return fs_mat
+                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_3_atoms_kernel!(fs_mat,
+            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
+            inter_list.ks, inter_list.inters, Val(D), Val(force_units))
+    return fs_mat
 end
 
 function specific_force_gpu!(fs_mat, inter_list::InteractionList4Atoms, coords::AbstractArray{SVector{D, C}},
-							velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_4_atoms_kernel!(fs_mat,
-			coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
-			inter_list.ks, inter_list.ls, inter_list.inters, Val(D), Val(force_units))
-	return fs_mat
+                            velocities, atoms, boundary, step_n, force_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_force_4_atoms_kernel!(fs_mat,
+            coords, velocities, atoms, boundary, step_n, inter_list.is, inter_list.js,
+            inter_list.ks, inter_list.ls, inter_list.inters, Val(D), Val(force_units))
+    return fs_mat
 end
 
 function specific_force_1_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-						step_n, is_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	inters = CUDA.Const(inters_var)
+                        step_n, is_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i = is[inter_i]
-		fs = force_gpu(inters[inter_i], coords[i], boundary, atoms[i], F, velocities[i], step_n)
-		if unit(fs.f1[1]) != F
-			error("wrong force unit returned, was expecting $F")
-		end
-		for dim in 1:D
-			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-		end
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i = is[inter_i]
+        fs = force_gpu(inters[inter_i], coords[i], boundary, atoms[i], F, velocities[i], step_n)
+        if unit(fs.f1[1]) != F
+            error("wrong force unit returned, was expecting $F")
+        end
+        for dim in 1:D
+            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+        end
+    end
+    return nothing
 end
 
 function specific_force_2_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-						step_n, is_var, js_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	js = CUDA.Const(js_var)
-	inters = CUDA.Const(inters_var)
+                        step_n, is_var, js_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    js = CUDA.Const(js_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i, j = is[inter_i], js[inter_i]
-		fs = force_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i], atoms[j], F,
-					   velocities[i], velocities[j], step_n)
-		if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F
-			error("wrong force unit returned, was expecting $F")
-		end
-		for dim in 1:D
-			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-			Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
-		end
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i, j = is[inter_i], js[inter_i]
+        fs = force_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i], atoms[j], F,
+                       velocities[i], velocities[j], step_n)
+        if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F
+            error("wrong force unit returned, was expecting $F")
+        end
+        for dim in 1:D
+            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+            Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
+        end
+    end
+    return nothing
 end
 
 function specific_force_3_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-						step_n, is_var, js_var, ks_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	js = CUDA.Const(js_var)
-	ks = CUDA.Const(ks_var)
-	inters = CUDA.Const(inters_var)
+                        step_n, is_var, js_var, ks_var, inters_var, ::Val{D}, ::Val{F}) where {D, F}
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    js = CUDA.Const(js_var)
+    ks = CUDA.Const(ks_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i, j, k = is[inter_i], js[inter_i], ks[inter_i]
-		fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary, atoms[i],
-					   atoms[j], atoms[k], F, velocities[i], velocities[j], velocities[k], step_n)
-		if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F
-			error("wrong force unit returned, was expecting $F")
-		end
-		for dim in 1:D
-			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-			Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
-			Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
-		end
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i, j, k = is[inter_i], js[inter_i], ks[inter_i]
+        fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary, atoms[i],
+                       atoms[j], atoms[k], F, velocities[i], velocities[j], velocities[k], step_n)
+        if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F
+            error("wrong force unit returned, was expecting $F")
+        end
+        for dim in 1:D
+            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+            Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
+            Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
+        end
+    end
+    return nothing
 end
 
 function specific_force_4_atoms_kernel!(forces, coords_var, velocities_var, atoms_var, boundary,
-						step_n, is_var, js_var, ks_var, ls_var, inters_var,
-						::Val{D}, ::Val{F}) where {D, F}
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	js = CUDA.Const(js_var)
-	ks = CUDA.Const(ks_var)
-	ls = CUDA.Const(ls_var)
-	inters = CUDA.Const(inters_var)
+                        step_n, is_var, js_var, ks_var, ls_var, inters_var,
+                        ::Val{D}, ::Val{F}) where {D, F}
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    js = CUDA.Const(js_var)
+    ks = CUDA.Const(ks_var)
+    ls = CUDA.Const(ls_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
-		fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l], boundary,
-					   atoms[i], atoms[j], atoms[k], atoms[l], F, velocities[i], velocities[j],
-					   velocities[k], velocities[l], step_n)
-		if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F || unit(fs.f4[1]) != F
-			error("wrong force unit returned, was expecting $F")
-		end
-		for dim in 1:D
-			Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
-			Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
-			Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
-			Atomix.@atomic :monotonic forces[dim, l] += ustrip(fs.f4[dim])
-		end
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
+        fs = force_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l], boundary,
+                       atoms[i], atoms[j], atoms[k], atoms[l], F, velocities[i], velocities[j],
+                       velocities[k], velocities[l], step_n)
+        if unit(fs.f1[1]) != F || unit(fs.f2[1]) != F || unit(fs.f3[1]) != F || unit(fs.f4[1]) != F
+            error("wrong force unit returned, was expecting $F")
+        end
+        for dim in 1:D
+            Atomix.@atomic :monotonic forces[dim, i] += ustrip(fs.f1[dim])
+            Atomix.@atomic :monotonic forces[dim, j] += ustrip(fs.f2[dim])
+            Atomix.@atomic :monotonic forces[dim, k] += ustrip(fs.f3[dim])
+            Atomix.@atomic :monotonic forces[dim, l] += ustrip(fs.f4[dim])
+        end
+    end
+    return nothing
 end
 
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList1Atoms, coords::AbstractArray{SVector{D, C}},
-						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_1_atoms_kernel!(
-			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-			inter_list.inters, Val(energy_units))
-	return pe_vec_nounits
+                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_1_atoms_kernel!(
+            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+            inter_list.inters, Val(energy_units))
+    return pe_vec_nounits
 end
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList2Atoms, coords::AbstractArray{SVector{D, C}},
-						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_2_atoms_kernel!(
-			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-			inter_list.js, inter_list.inters, Val(energy_units))
-	return pe_vec_nounits
+                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_2_atoms_kernel!(
+            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+            inter_list.js, inter_list.inters, Val(energy_units))
+    return pe_vec_nounits
 end
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList3Atoms, coords::AbstractArray{SVector{D, C}},
-						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_3_atoms_kernel!(
-			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-			inter_list.js, inter_list.ks, inter_list.inters, Val(energy_units))
-	return pe_vec_nounits
+                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_3_atoms_kernel!(
+            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+            inter_list.js, inter_list.ks, inter_list.inters, Val(energy_units))
+    return pe_vec_nounits
 end
 
 function specific_pe_gpu!(pe_vec_nounits, inter_list::InteractionList4Atoms, coords::AbstractArray{SVector{D, C}},
-						  velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
-	n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
-	CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_4_atoms_kernel!(
-			pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
-			inter_list.js, inter_list.ks, inter_list.ls, inter_list.inters, Val(energy_units))
-	return pe_vec_nounits
+                          velocities, atoms, boundary, step_n, energy_units, ::Val{T}) where {D, C, T}
+    n_threads_gpu, n_blocks = cuda_threads_blocks_specific(length(inter_list))
+    CUDA.@sync @cuda threads=n_threads_gpu blocks=n_blocks specific_pe_4_atoms_kernel!(
+            pe_vec_nounits, coords, velocities, atoms, boundary, step_n, inter_list.is,
+            inter_list.js, inter_list.ks, inter_list.ls, inter_list.inters, Val(energy_units))
+    return pe_vec_nounits
 end
 
 function specific_pe_1_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-					step_n, is_var, inters_var, ::Val{E}) where E
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	inters = CUDA.Const(inters_var)
+                    step_n, is_var, inters_var, ::Val{E}) where E
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i = is[inter_i]
-		pe = potential_energy_gpu(inters[inter_i], coords[i], boundary, atoms[i], E,
-								  velocities[i], step_n)
-		if unit(pe) != E
-			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-		end
-		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i = is[inter_i]
+        pe = potential_energy_gpu(inters[inter_i], coords[i], boundary, atoms[i], E,
+                                  velocities[i], step_n)
+        if unit(pe) != E
+            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+        end
+        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+    end
+    return nothing
 end
 
 function specific_pe_2_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-					step_n, is_var, js_var, inters_var, ::Val{E}) where E
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	js = CUDA.Const(js_var)
-	inters = CUDA.Const(inters_var)
+                    step_n, is_var, js_var, inters_var, ::Val{E}) where E
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    js = CUDA.Const(js_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i, j = is[inter_i], js[inter_i]
-		pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i],
-								  atoms[j], E, velocities[i], velocities[j], step_n)
-		if unit(pe) != E
-			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-		end
-		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i, j = is[inter_i], js[inter_i]
+        pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], boundary, atoms[i],
+                                  atoms[j], E, velocities[i], velocities[j], step_n)
+        if unit(pe) != E
+            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+        end
+        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+    end
+    return nothing
 end
 
 function specific_pe_3_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-					step_n, is_var, js_var, ks_var, inters_var, ::Val{E}) where E
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	js = CUDA.Const(js_var)
-	ks = CUDA.Const(ks_var)
-	inters = CUDA.Const(inters_var)
+                    step_n, is_var, js_var, ks_var, inters_var, ::Val{E}) where E
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    js = CUDA.Const(js_var)
+    ks = CUDA.Const(ks_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i, j, k = is[inter_i], js[inter_i], ks[inter_i]
-		pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary,
-								  atoms[i], atoms[j], atoms[k], E, velocities[i], velocities[j],
-								  velocities[k], step_n)
-		if unit(pe) != E
-			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-		end
-		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i, j, k = is[inter_i], js[inter_i], ks[inter_i]
+        pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], boundary,
+                                  atoms[i], atoms[j], atoms[k], E, velocities[i], velocities[j],
+                                  velocities[k], step_n)
+        if unit(pe) != E
+            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+        end
+        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+    end
+    return nothing
 end
 
 function specific_pe_4_atoms_kernel!(energy, coords_var, velocities_var, atoms_var, boundary,
-					step_n, is_var, js_var, ks_var, ls_var, inters_var, ::Val{E}) where E
-	coords = CUDA.Const(coords_var)
-	velocities = CUDA.Const(velocities_var)
-	atoms = CUDA.Const(atoms_var)
-	is = CUDA.Const(is_var)
-	js = CUDA.Const(js_var)
-	ks = CUDA.Const(ks_var)
-	ls = CUDA.Const(ls_var)
-	inters = CUDA.Const(inters_var)
+                    step_n, is_var, js_var, ks_var, ls_var, inters_var, ::Val{E}) where E
+    coords = CUDA.Const(coords_var)
+    velocities = CUDA.Const(velocities_var)
+    atoms = CUDA.Const(atoms_var)
+    is = CUDA.Const(is_var)
+    js = CUDA.Const(js_var)
+    ks = CUDA.Const(ks_var)
+    ls = CUDA.Const(ls_var)
+    inters = CUDA.Const(inters_var)
 
-	inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    inter_i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
-	@inbounds if inter_i <= length(is)
-		i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
-		pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l],
-								  boundary, atoms[i], atoms[j], atoms[k], atoms[l], E,
-								  velocities[i], velocities[j], velocities[k], velocities[l],
-								  step_n)
-		if unit(pe) != E
-			error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
-		end
-		Atomix.@atomic :monotonic energy[1] += ustrip(pe)
-	end
-	return nothing
+    @inbounds if inter_i <= length(is)
+        i, j, k, l = is[inter_i], js[inter_i], ks[inter_i], ls[inter_i]
+        pe = potential_energy_gpu(inters[inter_i], coords[i], coords[j], coords[k], coords[l],
+                                  boundary, atoms[i], atoms[j], atoms[k], atoms[l], E,
+                                  velocities[i], velocities[j], velocities[k], velocities[l],
+                                  step_n)
+        if unit(pe) != E
+            error("wrong energy unit returned, was expecting $E but got $(unit(pe))")
+        end
+        Atomix.@atomic :monotonic energy[1] += ustrip(pe)
+    end
+    return nothing
 end

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -57,7 +57,7 @@ function pairwise_force_gpu!(buffers, sys::System{D, true, T}, pairwise_inters, 
             buffers = ForcesBuffer(buffers.fs_mat, buffers.box_mins, buffers.box_maxs, buffers.Morton_seq)
 			sys.neighbor_finder.initialized = true
         end
-		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true force_kernel!(buffers.Morton_seq, buffers.fs_mat, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.force_units), pairwise_inters, sys.boundary, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, Val(T))
+		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) force_kernel!(buffers.Morton_seq, buffers.fs_mat, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.force_units), pairwise_inters, sys.boundary, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, Val(T))
 	end
     return buffers
 end
@@ -82,7 +82,7 @@ function pairwise_pe_gpu!(pe_vec_nounits, buffers, sys::System{D, true, T}, pair
 		CUDA.@sync @cuda blocks=(cld(N, WARPSIZE),) threads=(32,) kernel_min_max!(buffers.Morton_seq, buffers.box_mins, buffers.box_maxs, sys.coords, Val(N), sys.boundary)
 		buffers = ForcesBuffer(buffers.fs_mat, buffers.box_mins, buffers.box_maxs, buffers.Morton_seq)
 		sys.neighbor_finder.initialized = true
-		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) always_inline=true energy_kernel!(buffers.Morton_seq, 
+		CUDA.@sync @cuda blocks=(n_blocks, n_blocks) threads=(32, 1) energy_kernel!(buffers.Morton_seq, 
 		pe_vec_nounits, buffers.box_mins, buffers.box_maxs, sys.coords, sys.velocities, sys.atoms, Val(N), r_cut, Val(sys.energy_units), pairwise_inters, sys.boundary, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, Val(T))
 	end
 	return pe_vec_nounits

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -46,7 +46,7 @@ function pairwise_force_gpu!(buffers, sys::System{D, true, T}, pairwise_inters, 
         N = length(sys.coords)
         n_blocks = cld(N, WARPSIZE)
         r_cut = sys.neighbor_finder.dist_cutoff
-        if step_n % sys.neighbor_finder.n_steps_reorder == 0 || step_n == 1 || !sys.neighbor_finder.initialized
+        if step_n % sys.neighbor_finder.n_steps_reorder == 0 || !sys.neighbor_finder.initialized
             Morton_bits = 4
             w = r_cut - typeof(ustrip(r_cut))(0.1) * unit(r_cut)
             Morton_seq_cpu = sorted_Morton_seq(Array(sys.coords), w, Morton_bits)

--- a/src/energy.jl
+++ b/src/energy.jl
@@ -75,8 +75,7 @@ Calculate the potential energy due to a given interaction type.
 Custom interaction types should implement this function.
 """
 function potential_energy(sys; n_threads::Integer=Threads.nthreads())
-    buffers = init_forces_buffer(ustrip_vec.(zero(sys.coords)), sys.coords, n_threads)
-    return potential_energy(sys, find_neighbors(sys; n_threads=n_threads), buffers; n_threads=n_threads)
+    return potential_energy(sys, find_neighbors(sys; n_threads=n_threads); n_threads=n_threads)
 end
 
 function potential_energy(sys::System{D, false, T}, neighbors, step_n::Integer=0;
@@ -254,7 +253,8 @@ function specific_pe(atoms, coords, velocities, boundary, energy_units, sils_1_a
     return pe
 end
 
-function potential_energy(sys::System{D, true, T}, neighbors, buffers, step_n::Integer=0;
+function potential_energy(sys::System{D, true, T}, neighbors, step_n::Integer=0,
+                          buffers=init_forces_buffer(ustrip_vec.(zero(sys.coords)), sys.coords, 1);
                           n_threads::Integer=Threads.nthreads()) where {D, T}
     pe_vec_nounits = CUDA.zeros(T, 1)
     val_ft = Val(T)

--- a/src/energy.jl
+++ b/src/energy.jl
@@ -253,11 +253,11 @@ function specific_pe(atoms, coords, velocities, boundary, energy_units, sils_1_a
     return pe
 end
 
-function potential_energy(sys::System{D, true, T}, neighbors, step_n::Integer=0,
-                          buffers=init_forces_buffer(ustrip_vec.(zero(sys.coords)), sys.coords, 1);
+function potential_energy(sys::System{D, true, T}, neighbors, step_n::Integer=0;
                           n_threads::Integer=Threads.nthreads()) where {D, T}
     pe_vec_nounits = CUDA.zeros(T, 1)
     val_ft = Val(T)
+    buffers = init_forces_buffer!(sys, ustrip_vec.(zero(sys.coords)), 1)
 
     pairwise_inters_nonl = filter(!use_neighbors, values(sys.pairwise_inters))
     if length(pairwise_inters_nonl) > 0

--- a/src/force.jl
+++ b/src/force.jl
@@ -362,13 +362,8 @@ function forces_nounits!(fs_nounits, sys::System{D, true, T}, neighbors,
 
     pairwise_inters_nl = filter(use_neighbors, values(sys.pairwise_inters))
     if length(pairwise_inters_nl) > 0
-        if isnothing(neighbors)
-            error("an interaction uses the neighbor list but neighbors is nothing")
-        end
-        if length(neighbors) > 0
-            pairwise_force_gpu!(fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters_nl,
-                                nothing, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, sys.neighbor_finder.dist_cutoff, sys.force_units, val_ft)
-        end
+        pairwise_force_gpu!(fs_mat, sys.coords, sys.velocities, sys.atoms, sys.boundary, pairwise_inters_nl,
+                            nothing, step_n, sys.neighbor_finder.special, sys.neighbor_finder.eligible, sys.neighbor_finder.dist_cutoff, sys.force_units, val_ft)
     end
 
     for inter_list in values(sys.specific_inter_lists)

--- a/src/force.jl
+++ b/src/force.jl
@@ -123,11 +123,11 @@ function init_forces_buffer(forces_nounits, ::AbstractArray{SVector{D, C}}, n_th
     end
 end
 
-struct ForcesBuffer{F, C}
+struct ForcesBuffer{F, C, M}
     fs_mat::F
     box_mins::C
     box_maxs::C
-    Morton_seq::CuArray{Int32}
+    Morton_seq::M
 end
 
 function init_forces_buffer(forces_nounits::CuArray{SVector{D, T}}, ::AbstractArray{SVector{D, C}}, n_threads) where {D, T, C}

--- a/src/force.jl
+++ b/src/force.jl
@@ -123,11 +123,13 @@ function init_forces_buffer(forces_nounits, ::AbstractArray{SVector{D, C}}, n_th
     end
 end
 
-struct ForcesBuffer{F, C, M}
+struct ForcesBuffer{F, C, M, R}
     fs_mat::F
     box_mins::C
     box_maxs::C
     Morton_seq::M
+    compressed_eligible::R
+    compressed_special::R
 end
 
 function init_forces_buffer(forces_nounits::CuArray{SVector{D, T}}, ::AbstractArray{SVector{D, C}}, n_threads) where {D, T, C}
@@ -137,7 +139,9 @@ function init_forces_buffer(forces_nounits::CuArray{SVector{D, T}}, ::AbstractAr
     box_mins = CUDA.zeros(C, n_blocks, D) 
     box_maxs = CUDA.zeros(C, n_blocks, D) 
     Morton_seq = CUDA.zeros(Int32, N)
-    return ForcesBuffer(fs_mat, box_mins, box_maxs, Morton_seq)
+    compressed_eligible = CUDA.zeros(UInt32, 32, n_blocks, n_blocks)
+    compressed_special = CUDA.zeros(UInt32, 32, n_blocks, n_blocks)
+    return ForcesBuffer(fs_mat, box_mins, box_maxs, Morton_seq, compressed_eligible, compressed_special)
 end
 
 """

--- a/src/neighbors.jl
+++ b/src/neighbors.jl
@@ -394,7 +394,7 @@ function Base.show(io::IO, neighbor_finder::Union{DistanceNeighborFinder,
     print(  io, "  dist_cutoff = ", neighbor_finder.dist_cutoff)
 end
 
-function Base.show(io::IO, neighbor_finder::Union{GPUNeighborFinder})
+function Base.show(io::IO, neighbor_finder::GPUNeighborFinder)
     println(io, typeof(neighbor_finder))
     println(io, "  Size of eligible matrix = " , size(neighbor_finder.eligible))
     println(io, "  n_steps_reorder = " , neighbor_finder.n_steps_reorder)

--- a/src/neighbors.jl
+++ b/src/neighbors.jl
@@ -78,12 +78,15 @@ function GPUNeighborFinder(;
                             dist_cutoff,
                             special=zero(eligible),
                             n_steps_reorder=10,
-                            initialized)
+                            initialized=false)
     return GPUNeighborFinder{typeof(eligible), typeof(dist_cutoff)}(
-                eligible, dist_cutoff, special, n_steps_reorder, false)
+                eligible, dist_cutoff, special, n_steps_reorder, initialized)
 end
 
 find_neighbors(sys::System{D, true}, nf::GPUNeighborFinder, current_neighbors=nothing, step_n::Integer=0, initialized::Bool=false; kwargs...) where D = nothing
+
+find_neighbors(sys::System, nf::GPUNeighborFinder, args...; kwargs...) = nothing
+
 
 function find_neighbors(sys::System{D, false},
                         nf::DistanceNeighborFinder,

--- a/src/neighbors.jl
+++ b/src/neighbors.jl
@@ -44,27 +44,10 @@ find_neighbors(sys::System; kwargs...) = find_neighbors(sys, sys.neighbor_finder
 find_neighbors(sys::System, nf::NoNeighborFinder, args...; kwargs...) = nothing
 
 """
-    DistanceNeighborFinder(; eligible, dist_cutoff, special, n_steps)
+    GPUNeighborFinder(; eligible, dist_cutoff, special, n_steps_reorder, initialized)
 
-Find close atoms by distance.
+Returns nothing as neighbor list since the Eastman's algorithm for GPU computation of nonbonded forces does not require previous knowledge of a neighbor list. 
 """
-struct DistanceNeighborFinder{B, D}
-    eligible::B
-    dist_cutoff::D
-    special::B
-    n_steps::Int
-    neighbors::B # Used internally during neighbor calculation on the GPU
-end
-
-function DistanceNeighborFinder(;
-                                eligible,
-                                dist_cutoff,
-                                special=zero(eligible),
-                                n_steps=10)
-    return DistanceNeighborFinder{typeof(eligible), typeof(dist_cutoff)}(
-                eligible, dist_cutoff, special, n_steps, zero(eligible))
-end
-
 mutable struct GPUNeighborFinder{B, D}
     eligible::B
     dist_cutoff::D
@@ -87,6 +70,27 @@ find_neighbors(sys::System{D, true}, nf::GPUNeighborFinder, current_neighbors=no
 
 find_neighbors(sys::System, nf::GPUNeighborFinder, args...; kwargs...) = nothing
 
+"""
+    DistanceNeighborFinder(; eligible, dist_cutoff, special, n_steps)
+
+Find close atoms by distance.
+"""
+struct DistanceNeighborFinder{B, D}
+    eligible::B
+    dist_cutoff::D
+    special::B
+    n_steps::Int
+    neighbors::B # Used internally during neighbor calculation on the GPU
+end
+
+function DistanceNeighborFinder(;
+                                eligible,
+                                dist_cutoff,
+                                special=zero(eligible),
+                                n_steps=10)
+    return DistanceNeighborFinder{typeof(eligible), typeof(dist_cutoff)}(
+                eligible, dist_cutoff, special, n_steps, zero(eligible))
+end
 
 function find_neighbors(sys::System{D, false},
                         nf::DistanceNeighborFinder,

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -888,11 +888,12 @@ function System(coord_file::AbstractString,
     coords = wrap_coords.(coords, (boundary_used,))
 
     if gpu || !use_cell_list
-        neighbor_finder = DistanceNeighborFinder(
+        neighbor_finder = GPUNeighborFinder(
             eligible=(gpu ? CuArray(eligible) : eligible),
-            special=(gpu ? CuArray(special) : special),
-            n_steps=10,
             dist_cutoff=T(dist_neighbors),
+            special=(gpu ? CuArray(special) : special),
+            n_steps_reorder=10,
+            initialized=false,
         )
     else
         neighbor_finder = CellListMapNeighborFinder(
@@ -1277,11 +1278,12 @@ function System(T::Type,
     specific_inter_lists = tuple(specific_inter_array...)
 
     if gpu || !use_cell_list
-        neighbor_finder = DistanceNeighborFinder(
+        neighbor_finder = GPUNeighborFinder(
             eligible=(gpu ? CuArray(eligible) : eligible),
             special=(gpu ? CuArray(special) : special),
-            n_steps=10,
+            n_steps_reorder=10,
             dist_cutoff=T(dist_neighbors),
+            initialized=false,
         )
     else
         neighbor_finder = CellListMapNeighborFinder(

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -887,21 +887,28 @@ function System(coord_file::AbstractString,
     end
     coords = wrap_coords.(coords, (boundary_used,))
 
-    if gpu || !use_cell_list
+    if gpu
         neighbor_finder = GPUNeighborFinder(
-            eligible=(gpu ? CuArray(eligible) : eligible),
+            eligible=CuArray(eligible),
             dist_cutoff=T(dist_neighbors),
-            special=(gpu ? CuArray(special) : special),
+            special=CuArray(special),
             n_steps_reorder=10,
             initialized=false,
         )
-    else
+    elseif use_cell_list
         neighbor_finder = CellListMapNeighborFinder(
             eligible=eligible,
             special=special,
             n_steps=10,
             x0=coords,
             unit_cell=boundary_used,
+            dist_cutoff=T(dist_neighbors),
+        )
+    else
+        neighbor_finder = DistanceNeighborFinder(
+            eligible=eligible,
+            special=special,
+            n_steps=10,
             dist_cutoff=T(dist_neighbors),
         )
     end
@@ -1277,21 +1284,28 @@ function System(T::Type,
     end
     specific_inter_lists = tuple(specific_inter_array...)
 
-    if gpu || !use_cell_list
+    if gpu
         neighbor_finder = GPUNeighborFinder(
-            eligible=(gpu ? CuArray(eligible) : eligible),
-            special=(gpu ? CuArray(special) : special),
-            n_steps_reorder=10,
+            eligible=CuArray(eligible),
             dist_cutoff=T(dist_neighbors),
+            special=CuArray(special),
+            n_steps_reorder=10,
             initialized=false,
         )
-    else
+    elseif use_cell_list
         neighbor_finder = CellListMapNeighborFinder(
             eligible=eligible,
             special=special,
             n_steps=10,
             x0=coords,
             unit_cell=boundary_used,
+            dist_cutoff=T(dist_neighbors),
+        )
+    else
+        neighbor_finder = DistanceNeighborFinder(
+            eligible=eligible,
+            special=special,
+            n_steps=10,
             dist_cutoff=T(dist_neighbors),
         )
     end

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -73,9 +73,6 @@ Custom simulators should implement this function.
     F_nounits = ustrip_vec.(similar(sys.coords))
     F = F_nounits .* sys.force_units
     forces_buffer = init_forces_buffer(F_nounits, sys.coords, n_threads)
-    F_nounits = forces_nounits!(F_nounits, sys, neighbors, forces_buffer, 0;
-                                            n_threads=n_threads)
-    
 
     for step_n in 1:sim.max_steps
         F_nounits .= forces_nounits!(F_nounits, sys, neighbors, forces_buffer, step_n;
@@ -136,7 +133,7 @@ function VelocityVerlet(; dt, coupling=NoCoupling(), remove_CM_motion=1)
     return VelocityVerlet(dt, coupling, Int(remove_CM_motion))
 end
 
-@inline function simulate(sys,
+@inline function simulate!(sys,
                            sim::VelocityVerlet,
                            n_steps::Integer;
                            n_threads::Integer=Threads.nthreads(),
@@ -239,8 +236,6 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
-    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
-                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
     if using_constraints
@@ -317,8 +312,6 @@ StormerVerlet(; dt, coupling=NoCoupling()) = StormerVerlet(dt, coupling)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
-    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
-                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
 
@@ -403,8 +396,6 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
-    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
-                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
     using_constraints = length(sys.constraints) > 0
@@ -513,8 +504,6 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
-    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
-                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -635,8 +624,6 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
-    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
-                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -73,6 +73,9 @@ Custom simulators should implement this function.
     F_nounits = ustrip_vec.(similar(sys.coords))
     F = F_nounits .* sys.force_units
     forces_buffer = init_forces_buffer(F_nounits, sys.coords, n_threads)
+    F_nounits = forces_nounits!(F_nounits, sys, neighbors, forces_buffer, 0;
+                                            n_threads=n_threads)
+    
 
     for step_n in 1:sim.max_steps
         F_nounits .= forces_nounits!(F_nounits, sys, neighbors, forces_buffer, step_n;
@@ -142,11 +145,13 @@ end
     sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
-    forces_t = forces(sys, neighbors; n_threads=n_threads)
+    forces_nounits_t = ustrip_vec.(zero(sys.coords))
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0; n_threads=n_threads)
+    forces_t = forces_nounits_t .* sys.force_units
     accels_t = forces_t ./ masses(sys)
     forces_nounits_t_dt = ustrip_vec.(similar(sys.coords))
     forces_t_dt = forces_nounits_t_dt .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t_dt, sys.coords, n_threads)
     accels_t_dt = zero(accels_t)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads, current_forces=forces_t)
     using_constraints = length(sys.constraints) > 0
@@ -234,6 +239,8 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
+                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
     if using_constraints
@@ -310,6 +317,8 @@ StormerVerlet(; dt, coupling=NoCoupling()) = StormerVerlet(dt, coupling)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
+                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
 
@@ -394,6 +403,8 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
+                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
     using_constraints = length(sys.constraints) > 0
@@ -502,6 +513,8 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
+                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -622,6 +635,8 @@ end
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
     forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0;
+                                            n_threads=n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -692,11 +707,13 @@ end
     sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
-    forces_t = forces(sys, neighbors; n_threads=n_threads)
+    forces_nounits_t = ustrip_vec.(zero(sys.coords))
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0; n_threads=n_threads)
+    forces_t = forces_nounits_t .* sys.force_units
     accels_t = forces_t ./ masses(sys)
     forces_nounits_t_dt = ustrip_vec.(similar(sys.coords))
     forces_t_dt = forces_nounits_t_dt .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t_dt, sys.coords, n_threads)
     accels_t_dt = zero(accels_t)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads, current_forces=forces_t)
     v_half = zero(sys.velocities)

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -72,7 +72,7 @@ Custom simulators should implement this function.
     coords_copy = similar(sys.coords)
     F_nounits = ustrip_vec.(similar(sys.coords))
     F = F_nounits .* sys.force_units
-    forces_buffer = init_forces_buffer(F_nounits, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, F_nounits, n_threads)
 
     for step_n in 1:sim.max_steps
         F_nounits .= forces_nounits!(F_nounits, sys, neighbors, forces_buffer, step_n;
@@ -143,7 +143,7 @@ end
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(zero(sys.coords))
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0; n_threads=n_threads)
     forces_t = forces_nounits_t .* sys.force_units
     accels_t = forces_t ./ masses(sys)
@@ -235,7 +235,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
     if using_constraints
@@ -311,7 +311,7 @@ StormerVerlet(; dt, coupling=NoCoupling()) = StormerVerlet(dt, coupling)
     coords_last, coords_copy = similar(sys.coords), similar(sys.coords)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
 
@@ -395,7 +395,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
     using_constraints = length(sys.constraints) > 0
@@ -503,7 +503,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -623,7 +623,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -695,7 +695,7 @@ end
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(zero(sys.coords))
-    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
+    forces_buffer = init_forces_buffer!(sys, forces_nounits_t, n_threads)
     forces_nounits_t = forces_nounits!(forces_nounits_t, sys, neighbors, forces_buffer, 0; n_threads=n_threads)
     forces_t = forces_nounits_t .* sys.force_units
     accels_t = forces_t ./ masses(sys)

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -72,7 +72,7 @@ Custom simulators should implement this function.
     coords_copy = similar(sys.coords)
     F_nounits = ustrip_vec.(similar(sys.coords))
     F = F_nounits .* sys.force_units
-    forces_buffer = init_forces_buffer(F_nounits, n_threads)
+    forces_buffer = init_forces_buffer(F_nounits, sys.coords, n_threads)
 
     for step_n in 1:sim.max_steps
         F_nounits .= forces_nounits!(F_nounits, sys, neighbors, forces_buffer, step_n;
@@ -146,7 +146,7 @@ end
     accels_t = forces_t ./ masses(sys)
     forces_nounits_t_dt = ustrip_vec.(similar(sys.coords))
     forces_t_dt = forces_nounits_t_dt .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t_dt, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t_dt, sys.coords, n_threads)
     accels_t_dt = zero(accels_t)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads, current_forces=forces_t)
     using_constraints = length(sys.constraints) > 0
@@ -233,7 +233,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
     if using_constraints
@@ -309,7 +309,7 @@ StormerVerlet(; dt, coupling=NoCoupling()) = StormerVerlet(dt, coupling)
     coords_last, coords_copy = similar(sys.coords), similar(sys.coords)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
     accels_t = forces_t ./ masses(sys)
     using_constraints = length(sys.constraints) > 0
 
@@ -393,7 +393,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
     using_constraints = length(sys.constraints) > 0
@@ -501,7 +501,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -621,7 +621,7 @@ end
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(similar(sys.coords))
     forces_t = forces_nounits_t .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t, sys.coords, n_threads)
     accels_t = forces_t ./ masses(sys)
     noise = similar(sys.velocities)
 
@@ -696,7 +696,7 @@ end
     accels_t = forces_t ./ masses(sys)
     forces_nounits_t_dt = ustrip_vec.(similar(sys.coords))
     forces_t_dt = forces_nounits_t_dt .* sys.force_units
-    forces_buffer = init_forces_buffer(forces_nounits_t_dt, n_threads)
+    forces_buffer = init_forces_buffer(forces_nounits_t_dt, sys.coords, n_threads)
     accels_t_dt = zero(accels_t)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads, current_forces=forces_t)
     v_half = zero(sys.velocities)

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -136,7 +136,7 @@ function VelocityVerlet(; dt, coupling=NoCoupling(), remove_CM_motion=1)
     return VelocityVerlet(dt, coupling, Int(remove_CM_motion))
 end
 
-@inline function simulate!(sys,
+@inline function simulate(sys,
                            sim::VelocityVerlet,
                            n_steps::Integer;
                            n_threads::Integer=Threads.nthreads(),

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -184,7 +184,7 @@
         # Mark all pairs as ineligible for pairwise interactions and check that the
         #   potential energy from the specific interactions does not change on scaling
         no_nbs = falses(length(sys), length(sys))
-        sys.neighbor_finder = DistanceNeighborFinder(
+        sys.neighbor_finder = GPUNeighborFinder(
             eligible=(gpu ? CuArray(no_nbs) : no_nbs),
             dist_cutoff=1.0u"nm",
         )

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -184,10 +184,17 @@
         # Mark all pairs as ineligible for pairwise interactions and check that the
         #   potential energy from the specific interactions does not change on scaling
         no_nbs = falses(length(sys), length(sys))
-        sys.neighbor_finder = GPUNeighborFinder(
-            eligible=(gpu ? CuArray(no_nbs) : no_nbs),
-            dist_cutoff=1.0u"nm",
-        )
+        if gpu
+            sys.neighbor_finder = GPUNeighborFinder(
+                eligible=(gpu ? CuArray(no_nbs) : no_nbs),
+                dist_cutoff=1.0u"nm",
+            )
+        else 
+            sys.neighbor_finder = DistanceNeighborFinder(
+                eligible=(gpu ? CuArray(no_nbs) : no_nbs),
+                dist_cutoff=1.0u"nm",
+            )
+        end
         coords_start = copy(sys.coords)
         pe_start = potential_energy(sys, find_neighbors(sys))
         scale_factor = 1.02

--- a/test/energy_conservation.jl
+++ b/test/energy_conservation.jl
@@ -6,7 +6,7 @@ using CUDA
 using Test
 
 @testset "Lennard-Jones energy conservation" begin
-    function test_energy_conservation(gpu::Bool, n_threads::Integer, n_steps::Integer)
+    function test_energy_conservation(nl::Bool, gpu::Bool, n_threads::Integer, n_steps::Integer)
         n_atoms = 2_000
         atom_mass = 40.0u"g/mol"
         temp = 1.0u"K"
@@ -24,14 +24,15 @@ using Test
     
         for cutoff in cutoffs
             coords = place_atoms(n_atoms, boundary; min_dist=0.1u"nm")
-    
-            if gpu
+            neighbor_finder = NoNeighborFinder()
+            if nl && gpu
                 neighbor_finder=GPUNeighborFinder(
                     eligible=CuArray(trues(n_atoms, n_atoms)),
                     n_steps_reorder=10,
                     dist_cutoff=dist_cutoff,
                 )
-            else
+            end
+            if nl && !gpu
                 neighbor_finder=DistanceNeighborFinder(
                     eligible=trues(n_atoms, n_atoms),
                     n_steps=10,
@@ -71,12 +72,15 @@ using Test
         end
     end
 
-    test_energy_conservation(false, 1, 10_000)
+    test_energy_conservation(true, false, 1, 10_000)
+    test_energy_conservation(false, false, 1, 10_000)
     if Threads.nthreads() > 1
-        test_energy_conservation(false, Threads.nthreads(), 50_000)
+        test_energy_conservation(true, false, Threads.nthreads(), 50_000)
+        test_energy_conservation(false, false, Threads.nthreads(), 50_000)
     end
     if CUDA.functional()
-        test_energy_conservation(true, 1, 100_000)
+        test_energy_conservation(true, true, 1, 100_000)
+        test_energy_conservation(false, true, 1, 100_000)
     end
 end
 

--- a/test/energy_conservation.jl
+++ b/test/energy_conservation.jl
@@ -10,10 +10,10 @@ using Test
         n_atoms = 2_000
         atom_mass = 40.0u"g/mol"
         temp = 1.0u"K"
-        boundary = CubicBoundary(50.0u"nm")
+        boundary = CubicBoundary(5.0u"nm")
         simulator = VelocityVerlet(dt=0.001u"ps", remove_CM_motion=false)
-
-        atoms = [Atom(mass=atom_mass, charge=0.0, σ=0.3u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]
+    
+        atoms = [Atom(mass=atom_mass, charge=0.0, σ=0.05u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]
         dist_cutoff = 3.0u"nm"
         cutoffs = (
             DistanceCutoff(dist_cutoff),
@@ -21,35 +21,50 @@ using Test
             ShiftedForceCutoff(dist_cutoff),
             CubicSplineCutoff(dist_cutoff, dist_cutoff + 0.5u"nm"),
         )
-
+    
         for cutoff in cutoffs
-            coords = place_atoms(n_atoms, boundary; min_dist=0.6u"nm")
-
+            coords = place_atoms(n_atoms, boundary; min_dist=0.1u"nm")
+    
+            if gpu
+                neighbor_finder=GPUNeighborFinder(
+                    eligible=CuArray(trues(n_atoms, n_atoms)),
+                    n_steps_reorder=10,
+                    dist_cutoff=dist_cutoff,
+                )
+            else
+                neighbor_finder=DistanceNeighborFinder(
+                    eligible=trues(n_atoms, n_atoms),
+                    n_steps=10,
+                    dist_cutoff=dist_cutoff,
+                )
+            end
+    
             sys = System(
                 atoms=(gpu ? CuArray(atoms) : atoms),
                 coords=(gpu ? CuArray(coords) : coords),
                 boundary=boundary,
-                pairwise_inters=(LennardJones(cutoff=cutoff, use_neighbors=false),),
+                pairwise_inters=(LennardJones(cutoff=cutoff, use_neighbors=true),),
+                neighbor_finder=neighbor_finder,
                 loggers=(
                     coords=CoordinatesLogger(100),
                     energy=TotalEnergyLogger(100),
                 ),
             )
             random_velocities!(sys, temp)
-
+    
             E0 = total_energy(sys; n_threads=n_threads)
             simulate!(deepcopy(sys), simulator, 20; n_threads=n_threads)
             @time simulate!(sys, simulator, n_steps; n_threads=n_threads)
-
+    
             Es = values(sys.loggers.energy)
-            @test Es[1] == E0
-
+            @test isapprox(Es[1], E0; atol=1e-7u"kJ * mol^-1")
+    
             max_ΔE = maximum(abs.(Es .- E0))
             platform_str = gpu ? "GPU" : "CPU $n_threads thread(s)"
             cutoff_str = Base.typename(typeof(cutoff)).wrapper
             @info "$platform_str - $cutoff_str - max energy difference $max_ΔE"
             @test max_ΔE < 5e-4u"kJ * mol^-1"
-
+    
             final_coords = last(values(sys.loggers.coords))
             @test all(all(c .> 0.0u"nm") for c in final_coords)
             @test all(all(c .< boundary) for c in final_coords)
@@ -64,3 +79,5 @@ using Test
         test_energy_conservation(true, 1, 100_000)
     end
 end
+
+

--- a/test/energy_conservation.jl
+++ b/test/energy_conservation.jl
@@ -44,7 +44,7 @@ using Test
                 atoms=(gpu ? CuArray(atoms) : atoms),
                 coords=(gpu ? CuArray(coords) : coords),
                 boundary=boundary,
-                pairwise_inters=(LennardJones(cutoff=cutoff, use_neighbors=true),),
+                pairwise_inters=(LennardJones(cutoff=cutoff, use_neighbors=ifelse(nl, true, false)),),
                 neighbor_finder=neighbor_finder,
                 loggers=(
                     coords=CoordinatesLogger(100),

--- a/test/protein.jl
+++ b/test/protein.jl
@@ -67,6 +67,34 @@ end
     @test 3.6f0 < s.boundary.side_lengths[1] < 3.8f0
 end
 
+@testset "Peptide Float32 no units on GPU" begin
+    n_steps = 1_000
+    temp = 298.0f0
+    press = Float32(ustrip(u"u * nm^-1 * ps^-2", 1.0f0u"bar"))
+    s = System(
+        Float32,
+        joinpath(data_dir, "5XER", "gmx_coords.gro"),
+        joinpath(data_dir, "5XER", "gmx_top_ff.top");
+        loggers=(
+            temp=TemperatureLogger(Float32, 10),
+            coords=CoordinatesLogger(Float32, 10),
+            energy=TotalEnergyLogger(Float32, 10),
+        ),
+        gpu=true,
+        units=false,
+    )
+    thermostat = AndersenThermostat(temp, 10.0f0)
+    barostat = MonteCarloBarostat(press, temp, s.boundary; n_steps=20)
+    simulator = VelocityVerlet(dt=0.0002f0, coupling=(thermostat, barostat))
+
+    atoms = Array(s.atoms)
+    s.velocities = CuArray([random_velocity(mass(a), temp) .* 0.01f0 for a in atoms])
+    simulate!(deepcopy(s), simulator, 100; n_threads=1)
+    @time simulate!(s, simulator, n_steps; n_threads=1)
+    @test typeof(s.neighbor_finder).name.wrapper == GPUNeighborFinder
+    @test 3.6f0 < Array(s.boundary.side_lengths)[1] < 3.8f0
+end
+
 @testset "OpenMM protein comparison" begin
     ff = MolecularForceField(joinpath.(ff_dir, ["ff99SBildn.xml", "tip3p_standard.xml", "his.xml"])...)
     show(devnull, ff)

--- a/test/protein.jl
+++ b/test/protein.jl
@@ -289,8 +289,6 @@ end
                 kappa=1.0u"nm^-1",
             )
             neighbors = find_neighbors(sys)
-
-            #@test_throws ErrorException forces(sys, nothing)
             forces_molly = forces(sys)
             @test !any(d -> any(abs.(d) .> 1e-6u"kJ * mol^-1 * nm^-1"),
                         Array(forces_molly) .- Array(forces(sys, neighbors)))
@@ -299,7 +297,6 @@ end
             @test !any(d -> any(abs.(d) .> 1e-3u"kJ * mol^-1 * nm^-1"),
                         Array(forces_molly) .- forces_openmm)
 
-            #@test_throws ErrorException potential_energy(sys, nothing)
             E_molly = potential_energy(sys)
             @test E_molly ≈ potential_energy(sys, neighbors)
             openmm_E_fp = joinpath(openmm_dir, "energy_$solvent_model.txt")

--- a/test/protein.jl
+++ b/test/protein.jl
@@ -262,7 +262,7 @@ end
             )
             neighbors = find_neighbors(sys)
 
-            @test_throws ErrorException forces(sys, nothing)
+            #@test_throws ErrorException forces(sys, nothing)
             forces_molly = forces(sys)
             @test !any(d -> any(abs.(d) .> 1e-6u"kJ * mol^-1 * nm^-1"),
                         Array(forces_molly) .- Array(forces(sys, neighbors)))
@@ -271,7 +271,7 @@ end
             @test !any(d -> any(abs.(d) .> 1e-3u"kJ * mol^-1 * nm^-1"),
                         Array(forces_molly) .- forces_openmm)
 
-            @test_throws ErrorException potential_energy(sys, nothing)
+            #@test_throws ErrorException potential_energy(sys, nothing)
             E_molly = potential_energy(sys)
             @test E_molly ≈ potential_energy(sys, neighbors)
             openmm_E_fp = joinpath(openmm_dir, "energy_$solvent_model.txt")

--- a/test/protein.jl
+++ b/test/protein.jl
@@ -67,34 +67,6 @@ end
     @test 3.6f0 < s.boundary.side_lengths[1] < 3.8f0
 end
 
-@testset "Peptide Float32 no units on GPU" begin
-    n_steps = 1_000
-    temp = 298.0f0
-    press = Float32(ustrip(u"u * nm^-1 * ps^-2", 1.0f0u"bar"))
-    s = System(
-        Float32,
-        joinpath(data_dir, "5XER", "gmx_coords.gro"),
-        joinpath(data_dir, "5XER", "gmx_top_ff.top");
-        loggers=(
-            temp=TemperatureLogger(Float32, 10),
-            coords=CoordinatesLogger(Float32, 10),
-            energy=TotalEnergyLogger(Float32, 10),
-        ),
-        gpu=true,
-        units=false,
-    )
-    thermostat = AndersenThermostat(temp, 10.0f0)
-    barostat = MonteCarloBarostat(press, temp, s.boundary; n_steps=20)
-    simulator = VelocityVerlet(dt=0.0002f0, coupling=(thermostat, barostat))
-
-    atoms = Array(s.atoms)
-    s.velocities = CuArray([random_velocity(mass(a), temp) .* 0.01f0 for a in atoms])
-    simulate!(deepcopy(s), simulator, 100; n_threads=1)
-    @time simulate!(s, simulator, n_steps; n_threads=1)
-    @test typeof(s.neighbor_finder).name.wrapper == GPUNeighborFinder
-    @test 3.6f0 < Array(s.boundary.side_lengths)[1] < 3.8f0
-end
-
 @testset "OpenMM protein comparison" begin
     ff = MolecularForceField(joinpath.(ff_dir, ["ff99SBildn.xml", "tip3p_standard.xml", "his.xml"])...)
     show(devnull, ff)

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -409,7 +409,6 @@ end
     n_steps = 100
     temp = 298.0u"K"
     boundary = CubicBoundary(2.0u"nm")
-    G = 10.0u"kJ * mol * nm * g^-2"
     simulator = VelocityVerlet(dt=0.002u"ps")
     pairwise_inter_types = (
         LennardJones(use_neighbors=true), 
@@ -438,10 +437,10 @@ end
         velocities = [random_velocity(10.0u"g/mol", temp) .* 0.01 for i in 1:n_atoms]
 
         s = System(
-            atoms=atoms,
-            coords=coords,
-            boundary=boundary,
-            velocities=velocities,
+            atoms=deepcopy(atoms),
+            coords=deepcopy(coords),
+            boundary=deepcopy(boundary),
+            velocities=deepcopy(velocities),
             pairwise_inters=(inter,),
             neighbor_finder=neighbor_finder,
         )

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -9,7 +9,6 @@
     s = System(
         atoms=CuArray([Atom(mass=10.0u"g/mol", charge=0.0, σ=0.3u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]),
         coords=CuArray(place_atoms(n_atoms, boundary; min_dist=0.3u"nm")),
-        velocities=CuArray([random_velocity(10.0u"g/mol", temp) for i in 1:n_atoms]),
         boundary=boundary,
         pairwise_inters=(LennardJones(use_neighbors=true),),
         neighbor_finder=GPUNeighborFinder(
@@ -26,7 +25,9 @@
         ),
     )
 
-    @test masses(s) == fill(10.0u"g/mol", n_atoms)
+    random_velocities!(s, temp)
+
+    @test masses(s) == CuArray(fill(10.0u"g/mol", n_atoms))
     @test AtomsBase.cell_vectors(s) == (
         SVector(2.0, 0.0)u"nm",
         SVector(0.0, 2.0)u"nm",

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -221,8 +221,75 @@ end
     )
     random_velocities!(s, temp)
 
+    s_gpu = System(
+        atoms=CuArray([Atom(mass=10.0u"g/mol", charge=0.0, σ=0.3u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]),
+        coords=CuArray(coords),
+        boundary=boundary,
+        pairwise_inters=(LennardJones(use_neighbors=true),),
+        neighbor_finder=GPUNeighborFinder(
+            eligible=CuArray(trues(n_atoms, n_atoms)),
+            n_steps_reorder=10,
+            dist_cutoff=2.0u"nm",
+        ),
+        loggers=(coords=CoordinatesLogger(100),),
+    )
+
     for simulator in simulators
         @time simulate!(s, simulator, n_steps; n_threads=1)
+        @time simulate!(s_gpu, simulator, n_steps; n_threads=1)
+    end
+end
+
+@testset "Verlet integrators on CPU and GPU" begin
+    n_atoms = 100
+    n_steps = 1000
+    temp = 298.0u"K"
+    boundary = CubicBoundary(4.0u"nm")
+    coords = place_atoms(n_atoms, boundary; min_dist=0.2u"nm")
+    velocities = [random_velocity(10.0u"g/mol", temp) .* 0.01 for i in 1:n_atoms]
+    simulators = [
+        VelocityVerlet(dt=0.002u"ps"),
+        Verlet(dt=0.002u"ps"),
+        StormerVerlet(dt=0.002u"ps"),
+    ]
+
+    s = System(
+        atoms=[Atom(mass=10.0u"g/mol", charge=0.0, σ=0.1u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms],
+        coords=coords,
+        velocities=velocities,
+        boundary=boundary,
+        pairwise_inters=(LennardJones(use_neighbors=true),),
+        neighbor_finder=DistanceNeighborFinder(
+            eligible=trues(n_atoms, n_atoms),
+            n_steps=10,
+            dist_cutoff=2.0u"nm",
+        ),
+        loggers=(coords=CoordinatesLogger(100),),
+    )
+
+
+    s_gpu = System(
+        atoms=CuArray([Atom(mass=10.0u"g/mol", charge=0.0, σ=0.1u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]),
+        coords=CuArray(coords),
+        velocities=CuArray(velocities),
+        boundary=boundary,
+        pairwise_inters=(LennardJones(use_neighbors=true),),
+        neighbor_finder=GPUNeighborFinder(
+            eligible=CuArray(trues(n_atoms, n_atoms)),
+            n_steps_reorder=10,
+            dist_cutoff=2.0u"nm",
+        ),
+        loggers=(coords=CoordinatesLogger(100),),
+    )
+
+    for simulator in simulators
+        @time simulate!(s, simulator, n_steps; n_threads=1)
+        @time simulate!(s_gpu, simulator, n_steps; n_threads=1)
+        coord_diff = sum(sum(map(x -> abs.(x), s.coords .- Array(s_gpu.coords)))) / (3 * n_atoms)
+        E_diff = abs(potential_energy(s) - potential_energy(s_gpu))
+        @info "$(rpad(name, 19)) - difference per coordinate $coord_diff - potential energy difference $E_diff"
+        @test coord_diff < 1e-4u"nm"
+        @test E_diff < 5e-4u"kJ * mol^-1"
     end
 end
 
@@ -324,6 +391,67 @@ end
         )
 
         @time simulate!(s, simulator, n_steps)
+    end
+end
+
+@testset "LJ on CPU and GPU" begin
+    n_atoms = 100
+    n_steps = 100
+    temp = 298.0u"K"
+    boundary = CubicBoundary(2.0u"nm")
+    G = 10.0u"kJ * mol * nm * g^-2"
+    simulator = VelocityVerlet(dt=0.002u"ps")
+    pairwise_inter_types = (
+        LennardJones(use_neighbors=true), 
+        LennardJones(use_neighbors=false),
+        LennardJones(cutoff=DistanceCutoff(1.0u"nm"), use_neighbors=true),
+        LennardJones(cutoff=ShiftedPotentialCutoff(1.0u"nm"), use_neighbors=true),
+        LennardJones(cutoff=ShiftedForceCutoff(1.0u"nm"), use_neighbors=true),
+        LennardJones(cutoff=CubicSplineCutoff(0.6u"nm", 1.0u"nm"), use_neighbors=true),
+    )
+
+    for inter in pairwise_inter_types
+        if use_neighbors(inter)
+            neighbor_finder = DistanceNeighborFinder(eligible=trues(n_atoms, n_atoms), n_steps=10,
+                                                        dist_cutoff=1.2u"nm")
+        else
+            neighbor_finder = NoNeighborFinder()
+        end
+
+        neighbor_finder_gpu = GPUNeighborFinder(eligible=CuArray(trues(n_atoms, n_atoms)), n_steps_reorder=10,
+                                                        dist_cutoff=1.2u"nm")
+
+        atoms = [Atom(mass=10.0u"g/mol", charge=(i % 2 == 0 ? -1.0 : 1.0), σ=0.2u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]  
+        coords = place_atoms(n_atoms, boundary; min_dist=0.2u"nm")                                             
+        velocities = [random_velocity(10.0u"g/mol", temp) .* 0.01 for i in 1:n_atoms]
+
+        s = System(
+            atoms=atoms,
+            coords=coords,
+            boundary=boundary,
+            velocities=velocities,
+            pairwise_inters=(inter,),
+            neighbor_finder=neighbor_finder,
+        )
+
+        s_gpu = System(
+            atoms=CuArray(atoms),
+            coords=CuArray(coords),
+            boundary=boundary,
+            velocities=CuArray(velocities),
+            pairwise_inters=(inter,),
+            neighbor_finder=neighbor_finder_gpu,
+        )
+
+        E_diff_start = abs(potential_energy(s) - potential_energy(s_gpu))
+        @test E_diff_start < 5e-4u"kJ * mol^-1"
+        @time simulate!(s, simulator, n_steps)
+        @time simulate!(s_gpu, simulator, n_steps)
+        coord_diff = sum(sum(map(x -> abs.(x), s.coords .- Array(s_gpu.coords)))) / (3 * n_atoms)
+        E_diff = abs(potential_energy(s) - potential_energy(s_gpu))
+        @info "$(rpad(inter, 19)) - difference per coordinate $coord_diff - potential energy difference $E_diff_start (start) and $E_diff" 
+        @test coord_diff < 5e-4u"nm"
+        @test E_diff < 5e-3u"kJ * mol^-1"
     end
 end
 
@@ -1200,7 +1328,15 @@ end
         neighbor_finder = NoNeighborFinder()
         cutoff = DistanceCutoff(f32 ? 1.0f0u"nm" : 1.0u"nm")
         pairwise_inters = (LennardJones(use_neighbors=false, cutoff=cutoff),)
-        if nl
+        if nl && gpu
+            neighbor_finder = GPUNeighborFinder(
+                eligible=gpu ? CuArray(trues(n_atoms, n_atoms)) : trues(n_atoms, n_atoms),
+                n_steps_reorder=10,
+                dist_cutoff=f32 ? 1.5f0u"nm" : 1.5u"nm",
+            )
+            pairwise_inters = (LennardJones(use_neighbors=true, cutoff=cutoff),)
+        end
+        if nl && !gpu
             neighbor_finder = DistanceNeighborFinder(
                 eligible=gpu ? CuArray(trues(n_atoms, n_atoms)) : trues(n_atoms, n_atoms),
                 n_steps=10,


### PR DESCRIPTION
# Nonbonded force calculation using GPU block-based algorithm

This PR introduces a GPU-optimized algorithm for the calculation of nonbonded forces. The algorithm subdivides the system into blocks of 32 particles, evaluates distances between blocks, and computes forces only for interacting blocks within a cutoff radius. The algorithm is incorporated into OpenMM and it is described in a paper by Eastman and Pande (https://onlinelibrary.wiley.com/doi/full/10.1002/jcc.21413).

This new implementation significantly accelerates nonbonded force calculations for large systems as its performance scales linearly with the number of atoms. 

## Implementation details 

- The algorithm divides the N atoms in bounding boxes of 32. A bounding box is the smallest rectangular, axis-aligned  box that contains 32 atoms. The identification of these boxes is a O(N) problem. 
- For reasons of spatial coherence, a simple Morton code-based reordering algorithm is employed to ensure that atoms close in space are also close to each other in a reoredered array of indices. This is done by diving the 3D space into cubic small voxels with a side length `w` slightly smaller than the cutoff radius. The sequence obtained is used in the functions `kernel_min_max!`, `force_kernel!` and `energy_kernel`. 
 - `kernel_min_max!` : computes the arrays containing minima and maxima of the bounding boxes
- `force_kernel!`: computes the nonbonded forces between particles within interacting bounding boxes
- `energy_kernel`: computes the nonbonded potential energy 

Let `i` and `j` be the indices of the bounding boxes and let `n_blocks` be the allocated number of blocks of GPU threads, which matches exactly the number of bounding boxes. Each couple of bounding boxes forms a tile and the 32 threads allocated in each block compute the interactions within each tile. The structure of `force_kernel!` and `energy_kernel` is divided in 4 main parts:
1) `j < n_blocks && i < j`: computes the forces within 32x32 tiles by shuffling the coordinates, velocities indices of the particles and `Atom` objects  
2) `j == n_blocks && i < n_blocks`: computes the forces between the `r=N%32` particles in the last box and the particles in the other boxes of 32.
3) `i == j && i < n_blocks`: computes interaction within boxes of 32
4) `i == n_blocks && j == n_blocks`: computes interactions within the last box of `r` particles.
   
In cases 1 and 2, for each tile that has been identified as interacting, the distance of each atom in the first bounding box is computed with respect to the second bounding box and if not within the cutoff a flag is set for that atoms to skip the computation. 


## Observations and new neighbor finder (GPUNeighborFinder)

- The algorithm does not require a neighbor list to be passed as an input 
- The computation of the maxima and the minima is performed (by default) every 10 steps of dynamics. However, the user can modify this value by setting explicitly the field `n_steps_reorder` of `GPUNeighborFinder`. 
- `force_kernel!` and `energy_kernel` make explicit use of the matrices `eligible` and `special` defined in `GPUNeighborFinder`



`GPUNeighborFinder`: new type of neighbor finder for systems on GPU. For `GPUNeighborFinder` systems, the function `find_neighbors` returns `nothing` as a neighbor list. This because the new calculation does not require previous knowledge of the neighbor list. The new default choices for the setup of the system are displayed below (lines 890-914 of `setup.jl`):
```
if gpu
    neighbor_finder = GPUNeighborFinder(
        eligible=CuArray(eligible),
        dist_cutoff=T(dist_neighbors),
        special=CuArray(special),
        n_steps_reorder=10,
        initialized=false,
    )
elseif use_cell_list
    neighbor_finder = CellListMapNeighborFinder(
        eligible=eligible,
        special=special,
        n_steps=10,
        x0=coords,
        unit_cell=boundary_used,
        dist_cutoff=T(dist_neighbors),
    )
else
    neighbor_finder = DistanceNeighborFinder(
        eligible=eligible,
        special=special,
        n_steps=10,
        dist_cutoff=T(dist_neighbors),
    )
end
```

A new struct is introduced to store the forces matrix, the arrays of minima and maxima together with the sequence of atom indices ordered according to the Morton code. 
```
struct ForcesBuffer{F, C}
    fs_mat::F
    box_mins::C
    box_maxs::C
    Morton_seq::CuArray{Int32}
end
```

The function `forces_nounits!` takes now a `ForcesBuffer` object as an input. While the forces matrix is updated at each step of dynamics, the minima and maxima arrays and the Morton sequence are only updated every `n_steps_reorder` steps. 

Some tests for this GPU implementation are added in the `test/simulation.jl` and `test/protein.jl`. 


## Performance evaluation
Benchmark of `forces(sys)` performed on `6mrr_equil.pdb` (protein system with 15954 atoms) for the proposed implementation and the previous implementation in Molly: 

|          | `Float32` | `Float64` |
| -------- | -------   | -------   |
| with reordering  | 2.724 ms ± 340.828 μs | 8.018 ms ± 325.429 μs |
| without reordering  | 1.983 ms ± 26.878 μs | 7.134 ms ± 43.339 μs |
| previous implementation (with neighbors calculations)| 15.084 ms ± 399.510 μs |  20.113 ms ± 435.548 |
| previous implementation (without neighbors calculations)| 1.257 ms ± 115.581 μs |  1.585 ms ± 80.793 μs |

The old implementation still outperforms the new one in real systems simulations where the neighbor list is not computed at every step. However, I believe that small fixes can adjust the behaviour of the kernel in long simulations as the benchmark with the reordering seems encouraging. 

The command `potential_energy(sys)` always performs the reordering step in the new implementation since the potential energy will be computed much less frequently than the forces during a simulation.  

|          | `Float32` | `Float64` |
| -------- | -------   | -------   |
| with reordering  | 2.028 ms ± 254.345 μs | 7.783 ms ± 371.269 μs |
| previous implementation | 20.036 ms ± 523.120 μs |  24.720 ms ± 488.714 μs |



A possible setup for a benchmark with `Float64` precision:
```
n_atoms = 16_000
n_steps = 500
temp = 298.0u"K"
boundary = CubicBoundary(6.0u"nm")
coords = place_atoms(n_atoms, boundary; min_dist=0.1u"nm")
velocities = [random_velocity(10.0u"g/mol", temp) for i in 1:n_atoms]
simulator = VelocityVerlet(dt=0.002u"ps")

s = System(
    atoms=[Atom(mass=10.0u"g/mol", charge=0.0, σ=0.05u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms],
    coords=coords,
    velocities=velocities,
    boundary=boundary,
    pairwise_inters=(LennardJones(cutoff=DistanceCutoff(1.0u"nm"), use_neighbors=true),),
    neighbor_finder=DistanceNeighborFinder(
        eligible=trues(n_atoms, n_atoms),
        n_steps=10,
        dist_cutoff=1.2u"nm",
    ),
    loggers=(coords=CoordinatesLogger(100),),
)

s_gpu = System(
    atoms=CuArray([Atom(mass=10.0u"g/mol", charge=0.0, σ=0.05u"nm", ϵ=0.2u"kJ * mol^-1") for i in 1:n_atoms]),
    coords=CuArray(coords),
    velocities=CuArray(velocities),
    boundary=boundary,
    pairwise_inters=(LennardJones(cutoff=DistanceCutoff(1.0u"nm"), use_neighbors=true),),
    neighbor_finder=GPUNeighborFinder(
        eligible=CuArray(trues(n_atoms, n_atoms)),
        n_steps_reorder=10,
        dist_cutoff=1.0u"nm",
    ),
    loggers=(coords=CoordinatesLogger(100),),
)

# CPU 
simulate!(deepcopy(s), simulator, 20; n_threads=1)
@time simulate!(s, simulator, n_steps; n_threads=1)

# GPU
simulate!(deepcopy(s_gpu), simulator, 20; n_threads=1)
@time simulate!(s_gpu, simulator, n_steps; n_threads=1)
```


