### PR TITLE
Make Velocity Optional when Converting from AbstractSystem

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1260,8 +1260,8 @@ function System(sys::AtomsBase.AbstractSystem{D};
     end
 
     # AtomsBase does not specify a type for coordinates or velocities so we convert to SVector
-    if :position ∉ AtomsBase.atomkeys(sys)
-        throw(ArgumentError("Failed to construct Molly Sysmte form AbstractSystem. Missing position key."))
+    if !(:position in AtomsBase.atomkeys(sys))
+        throw(ArgumentError("Failed to construct Molly System form AbstractSystem. Missing position key."))
     end
     
     coords = map(AtomsBase.position(sys, :)) do r
@@ -1269,7 +1269,7 @@ function System(sys::AtomsBase.AbstractSystem{D};
     end
 
     vels = nothing
-    if :velocity ∈ AtomsBase.atomkeys(sys)
+    if :velocity in AtomsBase.atomkeys(sys)
         vels = map(AtomsBase.velocity(sys, :)) do v
             SVector(v...)
         end


### PR DESCRIPTION
This PR makes velocity optional when converting form an `AbstractSystem`. Velocity is not a required key I don't think and I currently get errors converting from the example implementation of `FastSystem` to a Molly `System`.

I noticed that we also always zero out the LJ parameters when converting form an AbstractSystem as they are not part of the AtomsBase interface. I'm pretty sure this means if you use the MollyCalculator with AtomsCalculators and LennardJones you will always get 0.0 for forces/energies. Fixing this is a much bigger change as again the sigma/epsilon probably do not belong in the AtomData class.