### PR TITLE
Track Image Flags

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -23,7 +23,9 @@ export
     AutoCorrelationLogger,
     AverageObservableLogger,
     ReplicaExchangeLogger,
-    MonteCarloLogger
+    MonteCarloLogger,
+    ImageFlagLogger, 
+    DisplacementLogger
 
 """
     apply_loggers!(system, neighbors=nothing, step_n=0, run_loggers=true;
@@ -299,6 +301,36 @@ end
 function virial_wrapper(sys, neighbors, step_n; n_threads, kwargs...)
     return virial(sys, neighbors, step_n; n_threads=n_threads)
 end
+
+
+image_flag_wrapper(sys, args...; kwargs...) = copy(sys.image_flags)
+
+"""
+    ImageFlagLogger(n_steps; dims::Integer=3)
+
+    Log the image flags of a atoms in the system throughout a simulation.
+"""
+function ImageFlagLogger(n_steps::Integer; dims::Integer=3)
+    return GeneralObservableLogger(
+        image_flag_wrapper,
+        Array{SArray{Tuple{dims}, Int32, 1, dims}, 1},
+        n_steps,
+    )
+end
+
+displacement_helper(sys, args...; kwargs...) = #*TODO CALCULATE DISPLACEMENTS HERE
+
+"""
+    DisplacementLogger(n_steps; dims=3)
+"""
+function DisplacementLogger(T, n_steps::Integer; dims::Integer=3)
+    return GeneralObservableLogger(
+        disp_wrapper,
+        Array{SArray{Tuple{dims}, T, 1, dims}, 1},
+        n_steps,
+    )
+end
+
 
 """
     VirialLogger(n_steps)

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -68,7 +68,7 @@ Custom simulators should implement this function.
                            run_loggers=false,
                            rng=Random.default_rng())
     # @inline needed to avoid Enzyme error
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     E = potential_energy(sys, neighbors; n_threads=n_threads)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads, current_potential_energy=E)
@@ -89,7 +89,7 @@ Custom simulators should implement this function.
         coords_copy .= sys.coords
         sys.coords .+= hn .* F ./ max_force
         using_constraints && apply_position_constraints!(sys, coords_copy; n_threads=n_threads)
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
 
         neighbors_copy = neighbors
         neighbors = find_neighbors(sys, sys.neighbor_finder, neighbors, step_n;
@@ -145,7 +145,7 @@ end
                            n_threads::Integer=Threads.nthreads(),
                            run_loggers=true,
                            rng=Random.default_rng())
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(zero(sys.coords))
@@ -172,7 +172,7 @@ end
         sys.coords .+= sys.velocities .* sim.dt .+ ((accels_t .* sim.dt .^ 2) ./ 2)
         using_constraints && apply_position_constraints!(sys, cons_coord_storage, cons_vel_storage,
                                                          sim.dt; n_threads=n_threads)
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
 
         forces_nounits_t_dt .= forces_nounits!(forces_nounits_t_dt, sys, neighbors, forces_buffer,
                                                step_n; n_threads=n_threads)
@@ -236,7 +236,7 @@ end
                            n_threads::Integer=Threads.nthreads(),
                            run_loggers=true,
                            rng=Random.default_rng())
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
@@ -268,7 +268,7 @@ end
             sys.velocities .= (sys.coords .- cons_coord_storage) ./ sim.dt
         end
 
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
 
         if !iszero(sim.remove_CM_motion) && step_n % sim.remove_CM_motion == 0
             remove_CM_motion!(sys)
@@ -312,7 +312,7 @@ StormerVerlet(; dt, coupling=NoCoupling()) = StormerVerlet(dt, coupling)
                            n_threads::Integer=Threads.nthreads(),
                            run_loggers=true,
                            rng=Random.default_rng())
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
     coords_last, coords_copy = zero(sys.coords), zero(sys.coords)
@@ -339,7 +339,7 @@ StormerVerlet(; dt, coupling=NoCoupling()) = StormerVerlet(dt, coupling)
 
         using_constraints && apply_position_constraints!(sys, coords_copy; n_threads=n_threads)
 
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
         # This is accurate to O(dt)
         sys.velocities .= vector.(coords_copy, sys.coords, (sys.boundary,)) ./ sim.dt
 
@@ -396,7 +396,7 @@ end
                            n_threads::Integer=Threads.nthreads(),
                            run_loggers=true,
                            rng=Random.default_rng())
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
@@ -432,7 +432,7 @@ end
 
         using_constraints && apply_position_constraints!(sys, cons_coord_storage, cons_vel_storage,
                                                          sim.dt; n_threads=n_threads)
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
 
         if !iszero(sim.remove_CM_motion) && step_n % sim.remove_CM_motion == 0
             remove_CM_motion!(sys)
@@ -504,7 +504,7 @@ end
     α_eff = exp.(-sim.friction * sim.dt .* M_inv / count('O', sim.splitting))
     σ_eff = sqrt.((1 * unit(eltype(α_eff))) .- (α_eff .^ 2))
 
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
@@ -553,7 +553,7 @@ end
             step!(args..., neighbors, step_n)
         end
 
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
         if !iszero(sim.remove_CM_motion) && step_n % sim.remove_CM_motion == 0
             remove_CM_motion!(sys)
         end
@@ -568,7 +568,7 @@ end
 
 function A_step!(sys, dt_eff, neighbors, step_n)
     sys.coords .+= sys.velocities .* dt_eff
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     return sys
 end
 
@@ -626,7 +626,7 @@ end
         @warn "OverdampedLangevin is not currently compatible with constraints, " *
               "constraints will be ignored"
     end
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     apply_loggers!(sys, neighbors, 0, run_loggers; n_threads=n_threads)
@@ -644,7 +644,7 @@ end
 
         random_velocities!(noise, sys, sim.temperature; rng=rng)
         sys.coords .+= (accels_t ./ sim.friction) .* sim.dt .+ sqrt((2 / sim.friction) * sim.dt) .* noise
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
 
         if !iszero(sim.remove_CM_motion) && step_n % sim.remove_CM_motion == 0
             remove_CM_motion!(sys)
@@ -701,7 +701,7 @@ end
         @warn "NoseHoover is not currently compatible with constraints, " *
               "constraints will be ignored"
     end
-    sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+    sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
     !iszero(sim.remove_CM_motion) && remove_CM_motion!(sys)
     neighbors = find_neighbors(sys, sys.neighbor_finder; n_threads=n_threads)
     forces_nounits_t = ustrip_vec.(zero(sys.coords))
@@ -721,7 +721,7 @@ end
         v_half .= sys.velocities .+ (accels_t .- (sys.velocities .* zeta)) .* (sim.dt ./ 2)
 
         sys.coords .+= v_half .* sim.dt
-        sys.coords .= wrap_coords.(sys.coords, (sys.boundary,))
+        sys.coords, sys.img_flags .= wrap_coords.(sys.coords, (sys.boundary,), sys.img_flags)
 
         zeta_half = zeta + (sim.dt / (2 * (sim.damping^2))) *
                                 ((temperature(sys) / sim.temperature) - 1)

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -465,15 +465,19 @@ trim3D(v::SVector{3, T}, boundary::RectangularBoundary{T}) where T = SVector{2, 
 trim3D(v::SVector{3}, boundary) = v
 
 """
-    wrap_coord_1D(c, side_length)
+    wrap_coord_1D(c, side_length, image_flag)
 
 Ensure a 1D coordinate is within the bounding box and return the coordinate.
+Update image flags to track which box each atom is in.
 """
-function wrap_coord_1D(c, side_length)
+function wrap_coord_1D(c, side_length, image_flag)
     if isinf(side_length)
-        return c
+        return c, image_flag
     else
-        return c - floor(c / side_length) * side_length
+        shift = floor(c / side_length)
+        c -= shift * side_length
+        image_flag += Int32(shift)
+        return c, image_flag
     end
 end
 
@@ -482,21 +486,29 @@ end
 
 Ensure a coordinate is within the bounding box and return the coordinate.
 """
-wrap_coords(v, boundary::Union{CubicBoundary, RectangularBoundary}) = wrap_coord_1D.(v, boundary)
+wrap_coords(v, boundary::Union{CubicBoundary, RectangularBoundary}, img_flags) = wrap_coord_1D.(v, boundary, img_flags)
 
-function wrap_coords(v, boundary::TriclinicBoundary)
+function wrap_coords(v, boundary::TriclinicBoundary, img_flags)
     bv, rs = boundary.basis_vectors, boundary.reciprocal_size
     v_wrap = v
     # Bound in z-axis
-    v_wrap -= bv[3] * floor(v_wrap[3] * rs[3])
+    iz = floor(v_wrap[3] * rs[3])
+    v_wrap -= bv[3] * iz
     # Bound in y-axis
-    v_wrap -= bv[2] * floor((v_wrap[2] - v_wrap[3] / boundary.tan_bprojyz_cprojyz) * rs[2])
+    y_term = (v_wrap[2] - v_wrap[3] / boundary.tan_bprojyz_cprojyz)
+    iy = floor(y_term * rs[2])
+    v_wrap -= bv[2] * iy
+
     dz_projxy = v_wrap[3] / boundary.tan_c_cprojxy
     dx = dz_projxy * boundary.cos_a_cprojxy
     dy = dz_projxy * boundary.sin_a_cprojxy
+
     # Bound in x-axis
-    v_wrap -= bv[1] * floor((v_wrap[1] - dx - (v_wrap[2] - dy) / boundary.tan_a_b) * rs[1])
-    return v_wrap
+    x_term = (v_wrap[1] - dx - (v_wrap[2] - dy) / boundary.tan_a_b)
+    ix = floor(x_term * rs[1])
+    v_wrap -= bv[1] * ix
+
+    return v_wrap, img_flags .+ SVector{Int32}(ix, iy, iz)
 end
 
 """


### PR DESCRIPTION
This PR adds an array of image flags which are updated by the `wrap_coordinates` function. This enables calculating displacements even when atoms move over the box boundary. This allows us to calculate things like MSD and displacement. 

I also added two loggers `ImageFlagLogger` and `DisplacementLogger`. I might also update the RMSD calculation in analysis.jl to reflect this change.