### PR TITLE
feat: Add new cutoff type PolynomialCutoff

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -1049,6 +1049,7 @@ The available cutoffs are:
 - [`ShiftedPotentialCutoff`](@ref)
 - [`ShiftedForceCutoff`](@ref)
 - [`CubicSplineCutoff`](@ref)
+- [`PolynomialCutoff`](@ref)
 
 The following built-in interactions can use a cutoff:
 - [`LennardJones`](@ref)

--- a/src/cutoffs.jl
+++ b/src/cutoffs.jl
@@ -5,7 +5,8 @@ export
     DistanceCutoff,
     ShiftedPotentialCutoff,
     ShiftedForceCutoff,
-    CubicSplineCutoff
+    CubicSplineCutoff,
+    PolynomialCutoff
 
 abstract type AbstractCutoff{P} end
 
@@ -197,4 +198,56 @@ function force_apply_cutoff(cutoff::CubicSplineCutoff, inter, r, params)
     dpe_dr_act = -pairwise_force(inter, cutoff.dist_activation, params)
     return -(6t^2 - 6t) * pe_act / (cutoff.dist_cutoff - cutoff.dist_activation) -
                     (3t^2 - 4t + 1) * dpe_dr_act
+end
+
+@doc raw"""
+    PolynomialCutoff(dist_activation, dist_cutoff)
+
+Cutoff that multiplies the potential by a 5th-degree polynomial switching function
+between an activation distance and a cutoff distance, smoothly reducing it to zero
+at the cutoff distance.
+Equivalent to the switching function used in OpenMM.
+
+```math
+\begin{aligned}
+V_c(r) &= \begin{cases}
+V(r), r \le r_a \\
+S(r) V(r), r_a < r \le r_c \\
+0, r > r_c
+\end{cases} \\
+F_c(r) &= \begin{cases}
+F(r), r \le r_a \\
+S(r) F(r) - S'(r) V(r), r_a < r \le r_c \\
+0, r > r_c
+\end{cases} \\
+S(r) &= 1 - 6t^5 + 15t^4 - 10t^3 \\
+S'(r) &= \frac{-30t^4 + 60t^3 - 30t^2}{r_c - r_a} \\
+t &= \frac{r - r_a}{r_c - r_a}
+\end{aligned}
+```
+"""
+struct PolynomialCutoff{P, D} <: AbstractCutoff{2}
+    dist_activation::D
+    dist_cutoff::D
+end
+
+function PolynomialCutoff(dist_activation::D, dist_cutoff) where D
+    if dist_cutoff <= dist_activation
+        throw(ArgumentError("the cutoff radius $dist_cutoff must be larger " *
+                            "than the activation radius $dist_activation"))
+    end
+    return PolynomialCutoff{2, D}(dist_activation, dist_cutoff)
+end
+
+function pe_apply_cutoff(cutoff::PolynomialCutoff, inter, r, params)
+    t = (r - cutoff.dist_activation) / (cutoff.dist_cutoff - cutoff.dist_activation)
+    S = 1 - 6t^5 + 15t^4 - 10t^3
+    return S * pairwise_pe(inter, r, params)
+end
+
+function force_apply_cutoff(cutoff::PolynomialCutoff, inter, r, params)
+    t = (r - cutoff.dist_activation) / (cutoff.dist_cutoff - cutoff.dist_activation)
+    S = 1 - 6t^5 + 15t^4 - 10t^3
+    dS_dr = (-30t^4 + 60t^3 - 30t^2) / (cutoff.dist_cutoff - cutoff.dist_activation)
+    return S * pairwise_force(inter, r, params) - dS_dr * pairwise_pe(inter, r, params)
 end

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -1250,6 +1250,7 @@ end
         (ShiftedPotentialCutoff(dist_cut)     , -0.04196301990 * fu, -0.00270785727 * eu),
         (ShiftedForceCutoff(dist_cut)         , -0.02537033587 * fu, -0.00104858887 * eu),
         (CubicSplineCutoff(dist_act, dist_cut), -0.06201171875 * fu, -0.00312500000 * eu),
+        (PolynomialCutoff(dist_act, dist_cut) , -0.06716652806 * fu, -0.00246320097 * eu),
     ]
 
     for (cutoff, force_ref, pe_ref) in cutoffs


### PR DESCRIPTION
## Summary

- Adds `PolynomialCutoff`, a new cutoff strategy that multiplies the potential by the quintic switching function used by OpenMM: `S(t) = 1 - 6t⁵ + 15t⁴ - 10t³`, where `t = (r - r_switch) / (r_cutoff - r_switch)`
- The force includes both `S(r)·F(r)` and a correction term `-S′(r)·V(r)` to stay consistent with the modified potential
- `S` and its first two derivatives are zero at `r_cutoff`, giving C² continuity at both endpoints — unlike `CubicSplineCutoff` (Hermite interpolation from the activation point), this scales the true interaction throughout the switching region without needing to evaluate `V` and `F` at the activation distance

## Test plan

- [X] New entry added to the `Cutoffs` testset in `test/interactions.jl` — checks force and PE at `r = 0.7 nm` (in the switching region) against exact reference values, and verifies zero force/PE at `r = 0.95 nm` and `r = 1.0 nm` (beyond cutoff)
- [X] All 32 cutoff tests pass locally