### PR TITLE
Remove unused NxN matrix in OBC calculations

### DIFF
--- a/src/interactions/implicit_solvent.jl
+++ b/src/interactions/implicit_solvent.jl
@@ -641,6 +641,11 @@ end
 get_i1(x) = @inbounds x[1]
 get_i2(x) = @inbounds x[2]
 
+struct EmptyIgrads end
+
+Base.getindex(::EmptyIgrads, i, j) = EmptyIgrads()
+Base.:-(x, ::EmptyIgrads) = x
+
 function born_radii_sum(or, offset, I, α, β, γ)
     radius = or + offset
     ψ = I * or
@@ -665,13 +670,11 @@ function born_radii_and_grad(inter::ImplicitSolventOBC{T}, coords, boundary) whe
         end
         Is[i] = I
     end
-    I_grads = zeros(eltype(Is), length(Is), length(Is)) ./ unit(inter.dist_cutoff)
-
     Bs_B_grads = born_radii_sum.(inter.offset_radii, inter.offset, Is,
                                  inter.α, inter.β, inter.γ)
     Bs      = get_i1.(Bs_B_grads)
     B_grads = get_i2.(Bs_B_grads)
-    return Bs, B_grads, I_grads
+    return Bs, B_grads, EmptyIgrads()
 end
 
 function born_radii_and_grad(inter::ImplicitSolventOBC, coords::AbstractGPUArray, boundary)
@@ -680,13 +683,12 @@ function born_radii_and_grad(inter::ImplicitSolventOBC, coords::AbstractGPUArray
     loop_res = born_radii_loop_OBC.(coords_i, coords_j, inter.oris, inter.srjs,
                                     inter.dist_cutoff, (boundary,))
     Is = dropdims(sum(loop_res; dims=2); dims=2)
-    I_grads = zero(loop_res) ./ unit(inter.dist_cutoff)
 
     Bs_B_grads = born_radii_sum.(inter.offset_radii, inter.offset, Is,
                                  inter.α, inter.β, inter.γ)
     Bs      = get_i1.(Bs_B_grads)
     B_grads = get_i2.(Bs_B_grads)
-    return Bs, B_grads, I_grads
+    return Bs, B_grads, EmptyIgrads()
 end
 
 function born_radii_loop_GBN2(coord_i::SVector{D, C}, coord_j, ori, orj, srj, dist_cutoff,
@@ -895,6 +897,7 @@ function gb_force_loop_2(coord_i, coord_j, bi, ig, ori, srj, dist_cutoff, bounda
     end
 end
 
+
 function forces_gbsa!(fs, sys, inter, Bs, B_grads, I_grads, born_forces, atom_charges)
     coords, boundary = sys.coords, sys.boundary
     born_forces_1 = copy(born_forces)
@@ -914,7 +917,8 @@ function forces_gbsa!(fs, sys, inter, Bs, B_grads, I_grads, born_forces, atom_ch
     born_forces_2 = born_forces_1 .* (Bs .^ 2) .* B_grads
     @inbounds for i in eachindex(sys)
         for j in eachindex(sys)
-            f = gb_force_loop_2(coords[i], coords[j], born_forces_2[i], I_grads[i, j],
+            f = gb_force_loop_2(coords[i], coords[j], born_forces_2[i],
+                                I_grads[i, j],
                                 inter.oris[i], inter.srjs[j], inter.dist_cutoff, boundary)
             fs[i] = fs[i] .- f
             fs[j] = fs[j] .+ f
@@ -1032,7 +1036,7 @@ end
 @kernel function gbsa_force_2_kernel!(forces, born_forces, @Const(coords),
                                       boundary, dist_cutoff, @Const(or),
                                       @Const(sor), @Const(Bs),
-                                      @Const(B_grads), @Const(I_grads),
+                                      @Const(B_grads), I_grads,
                                       ::Val{D}, ::Val{F}) where {D, F}
     n_atoms = length(coords)
     n_inters = n_atoms ^ 2


### PR DESCRIPTION
While looking through the OBC implicit solvent implementation I noticed that born_radii_and_grad allocates a zeros N×N matrix on every step that is never written to. This PR removes it and returns nothing instead, dispatching to a new CPU and GPU code path that skips the unused term.

I am aware that this duplicates quite a bit of code, but I wasn't sure how you'd prefer to handle that.
There is a small benchmark I just used to check if what I did actually has an effect, it can be removed if it is not necessary.
I don't know how much this actually affects real simulation performance, possibly the difference will be negligible.

Before
```
n_atoms   alloc (bytes)   median (ms)
------------------------------------
50        51712           0.12
100       181312          0.54
200       682528          2.50
400       2639840         10.21
```

After
```
n_atoms   alloc (bytes)   median (ms)
------------------------------------
50        11472           0.11
100       21136           0.53
200       38840           2.11
400       75712           8.76
```