### PR TITLE
Support for Inf dielectric constant for soft core reaction field interactions

### DIFF
--- a/src/interactions/coulomb.jl
+++ b/src/interactions/coulomb.jl
@@ -724,6 +724,8 @@ end
 
     if special
         krf = inv(rc^3) * zero(T)
+    elseif isinf(inter.solvent_dielectric) # Conducting boundary conditions
+        krf = inv(2 * rc^3)
     else
         krf = inv(rc^3) * ((inter.solvent_dielectric - 1) / (2 * inter.solvent_dielectric + 1))
     end
@@ -774,6 +776,9 @@ end
         if special
             krf = inv(rc^3) * zero(T)
             crf = inv(rc) * zero(T)
+        elseif isinf(inter.solvent_dielectric) # Conducting boundary conditions
+            krf = inv(2 * rc^3)
+            crf = 3 * inv(2 * rc)
         else
             krf = inv(rc^3) * ((inter.solvent_dielectric - 1) / (2 * inter.solvent_dielectric + 1))
             crf = inv(rc) * ((3 * inter.solvent_dielectric) / (2 * inter.solvent_dielectric + 1))
@@ -794,7 +799,11 @@ end
         pe = λ * (ke * qi * qj) * inv(R_eff)
         return pe * inter.weight_special * (r <= rc)
     else
-        krf = inv(rc^3) * ((inter.solvent_dielectric - 1) / (2 * inter.solvent_dielectric + 1))
+        if isinf(inter.solvent_dielectric) # Conducting boundary conditions
+            krf = inv(2 * rc^3)
+        else
+            krf = inv(rc^3) * ((inter.solvent_dielectric - 1) / (2 * inter.solvent_dielectric + 1))
+        end
         crf_λ = inv(sqrt(cbrt(inter.α * (1 - λ) * σ6 + rc^6))) + krf * rc^2
         pe = λ * (ke * qi * qj) * (inv(R_eff) + krf * r2 - crf_λ)
         return pe * (r <= rc)
@@ -884,6 +893,8 @@ end
 
     if special
         krf = inv(rc^3) * zero(T)
+    elseif isinf(inter.solvent_dielectric) # Conducting boundary conditions
+        krf = inv(2 * rc^3)
     else
         krf = inv(rc^3) * ((inter.solvent_dielectric - 1) / (2 * inter.solvent_dielectric + 1))
     end
@@ -936,6 +947,9 @@ end
     if special
         krf = inv(rc^3) * zero(T)
         crf = inv(rc) * zero(T)
+    elseif isinf(inter.solvent_dielectric) # Conducting boundary conditions
+        krf = inv(2 * rc^3)
+        crf = 3 * inv(2 * rc)
     else
         krf = inv(rc^3) * ((inter.solvent_dielectric - 1) / (2 * inter.solvent_dielectric + 1))
         crf = inv(rc) * ((3 * inter.solvent_dielectric) / (2 * inter.solvent_dielectric + 1))

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -442,6 +442,56 @@
                 )
             end
         end
+
+        @testset "conducting boundary conditions" begin
+            crf_ref_inf = CoulombReactionField(dist_cutoff=rc_test, solvent_dielectric=Inf)
+            cscrfb_inf = CoulombSoftCoreBeutlerReactionField(
+                dist_cutoff=rc_test, solvent_dielectric=Inf, α=1.0,
+            )
+            cscrfg_inf = CoulombSoftCoreGapsysReactionField(
+                dist_cutoff=rc_test, solvent_dielectric=Inf, α=0.3, σQ=1.0u"nm",
+            )
+
+            # λ = 1 reduces to base reaction field at Inf, with no NaN
+            for dr_test in (dr12, dr13, dr14)
+                ref_f = force(crf_ref_inf, dr_test, a1_rf, a1_rf)
+                ref_pe = potential_energy(crf_ref_inf, dr_test, a1_rf, a1_rf)
+                @test all(isfinite, ref_f)
+                @test isfinite(ref_pe)
+                @test isapprox(force(cscrfb_inf, dr_test, a1_rf, a1_rf), ref_f;
+                               atol=1e-9u"kJ * mol^-1 * nm^-1")
+                @test isapprox(force(cscrfg_inf, dr_test, a1_rf, a1_rf), ref_f;
+                               atol=1e-9u"kJ * mol^-1 * nm^-1")
+                @test isapprox(potential_energy(cscrfb_inf, dr_test, a1_rf, a1_rf), ref_pe;
+                               atol=1e-9u"kJ * mol^-1")
+                @test isapprox(potential_energy(cscrfg_inf, dr_test, a1_rf, a1_rf), ref_pe;
+                               atol=1e-9u"kJ * mol^-1")
+            end
+
+            # λ = 0.5 stays finite and nonzero (previously NaN without isinf handling)
+            for inter_rf in (cscrfb_inf, cscrfg_inf)
+                for dr_test in (dr12, dr13, dr14)
+                    f_val = force(inter_rf, dr_test, a1_l05, a1_l05)
+                    pe_val = potential_energy(inter_rf, dr_test, a1_l05, a1_l05)
+                    @test all(isfinite, f_val)
+                    @test isfinite(pe_val)
+                    @test !all(iszero, f_val)
+                    @test !iszero(pe_val)
+                end
+            end
+
+            # potential is zero at the cutoff under conducting boundary conditions
+            @test isapprox(potential_energy(cscrfb_inf, dr_rc, a1_l05, a1_l05),
+                           0.0u"kJ * mol^-1"; atol=1e-10u"kJ * mol^-1")
+            @test isapprox(potential_energy(cscrfg_inf, dr_rc, a1_l05, a1_l05),
+                           0.0u"kJ * mol^-1"; atol=1e-10u"kJ * mol^-1")
+
+            # values vanish beyond cutoff under conducting boundary conditions
+            for inter_rf in (cscrfb_inf, cscrfg_inf)
+                @test all(iszero, force(inter_rf, dr_beyond, a1_l05, a1_l05))
+                @test iszero(potential_energy(inter_rf, dr_beyond, a1_l05, a1_l05))
+            end
+        end
     end
 
     @testset "Soft-core Ewald" begin


### PR DESCRIPTION
A while ago I [proposed support for conducting boundary conditions](https://github.com/JuliaMolSim/Molly.jl/pull/247) for the CoulombReactionField. This PR adds the same functionality to the recently added soft-core variants.