### PR TITLE
added CUDA kernel for random_velocities!

### DIFF
--- a/ext/MollyCUDAExt.jl
+++ b/ext/MollyCUDAExt.jl
@@ -19,7 +19,8 @@ module MollyCUDAExt
 
 using Molly
 using Molly: from_device, box_sides, sorted_morton_seq!, sum_pairwise_forces_gpu,
-             sum_pairwise_forces_nonl, sum_pairwise_potentials_gpu, volume
+             sum_pairwise_forces_nonl, sum_pairwise_potentials_gpu, volume, random_velocities!, remove_CM_motion!
+
 using CUDA
 using Atomix
 using KernelAbstractions
@@ -2341,5 +2342,41 @@ function pairwise_force_kernel_nonl!(forces::AbstractArray{T}, coords_var, veloc
 
     return nothing
 end
+
+import Molly.random_velocities! 
+
+function random_velocities!(vels::CuArray, sys::Molly.AbstractSystem, temp; rng)
+    T = typeof(convert(AbstractFloat, ustrip(temp)))
+    V = unit(eltype(eltype(vels))) ### avoids SVector
+    masses=Molly.masses(sys)
+
+    M = unit(eltype(masses))
+    units =  T(ustrip(uconvert(V^2,T(sys.k) * temp / M))) ### use square units
+
+    N = length(vels)
+    raw_ptr = CuPtr{T}(Base.pointer(vels))
+
+    GC.@preserve vels masses begin
+        flat_vels_raw = Base.unsafe_wrap(CuArray, raw_ptr   , (3*N,))
+
+        CUDA.@cuda threads=256 blocks=cld(N, 256) fastmath=true random_velocities_kernel!(flat_vels_raw,ustrip.(masses), N,units)
+    end
+    
+    return vels 
+end
+
+function random_velocities_kernel!(vels,masses, N,units)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= N
+        @inbounds scale = sqrt(units/masses[i])
+        base_idx = 3 * (i - 1)
+
+        @inbounds vels[base_idx+1] = randn() * scale
+        @inbounds vels[base_idx+2] = randn() * scale
+        @inbounds vels[base_idx+3] = randn() * scale
+    end
+    return nothing
+end
+
 
 end

--- a/ext/MollyCUDAExt.jl
+++ b/ext/MollyCUDAExt.jl
@@ -2343,40 +2343,4 @@ function pairwise_force_kernel_nonl!(forces::AbstractArray{T}, coords_var, veloc
     return nothing
 end
 
-import Molly.random_velocities! 
-
-function random_velocities!(vels::CuArray, sys::Molly.AbstractSystem, temp; rng)
-    T = typeof(convert(AbstractFloat, ustrip(temp)))
-    V = unit(eltype(eltype(vels))) ### avoids SVector
-    masses=Molly.masses(sys)
-
-    M = unit(eltype(masses))
-    units =  T(ustrip(uconvert(V^2,T(sys.k) * temp / M))) ### use square units
-
-    N = length(vels)
-    raw_ptr = CuPtr{T}(Base.pointer(vels))
-
-    GC.@preserve vels masses begin
-        flat_vels_raw = Base.unsafe_wrap(CuArray, raw_ptr   , (3*N,))
-
-        CUDA.@cuda threads=256 blocks=cld(N, 256) fastmath=true random_velocities_kernel!(flat_vels_raw,ustrip.(masses), N,units)
-    end
-    
-    return vels 
-end
-
-function random_velocities_kernel!(vels,masses, N,units)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= N
-        @inbounds scale = sqrt(units/masses[i])
-        base_idx = 3 * (i - 1)
-
-        @inbounds vels[base_idx+1] = randn() * scale
-        @inbounds vels[base_idx+2] = randn() * scale
-        @inbounds vels[base_idx+3] = randn() * scale
-    end
-    return nothing
-end
-
-
 end

--- a/ext/MollyCUDAExt.jl
+++ b/ext/MollyCUDAExt.jl
@@ -20,6 +20,7 @@ module MollyCUDAExt
 using Molly
 using Molly: from_device, box_sides, sorted_morton_seq!, sum_pairwise_forces_gpu,
              sum_pairwise_forces_nonl, sum_pairwise_potentials_gpu, volume
+
 using CUDA
 using Atomix
 using KernelAbstractions
@@ -2341,5 +2342,41 @@ function pairwise_force_kernel_nonl!(forces::AbstractArray{T}, coords_var, veloc
 
     return nothing
 end
+
+import Molly.random_velocities! 
+
+function random_velocities!(vels::CuArray, sys::Molly.AbstractSystem, temp; rng)
+    T = typeof(convert(AbstractFloat, ustrip(temp)))
+    V = unit(eltype(eltype(vels))) ### avoids SVector
+    masses=Molly.masses(sys)
+
+    M = unit(eltype(masses))
+    units =  T(ustrip(uconvert(V^2,T(sys.k) * temp / M))) ### use square units
+
+    N = length(vels)
+    raw_ptr = CuPtr{T}(Base.pointer(vels))
+
+    GC.@preserve vels masses begin
+        flat_vels_raw = Base.unsafe_wrap(CuArray, raw_ptr   , (3*N,))
+
+        CUDA.@cuda threads=256 blocks=cld(N, 256) fastmath=true random_velocities_kernel!(flat_vels_raw,ustrip.(masses), N,units)
+    end
+    
+    return vels 
+end
+
+function random_velocities_kernel!(vels,masses, N,units)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= N
+        @inbounds scale = sqrt(units/masses[i])
+        base_idx = 3 * (i - 1)
+
+        @inbounds vels[base_idx+1] = randn() * scale
+        @inbounds vels[base_idx+2] = randn() * scale
+        @inbounds vels[base_idx+3] = randn() * scale
+    end
+    return nothing
+end
+
 
 end

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -177,12 +177,9 @@ function apply_coupling!(sys::System{<:Any, AT, T}, buffers, thermostat::Anderse
                          neighbors=nothing, step_n::Integer=0;
                          n_threads::Integer=Threads.nthreads(),
                          rng=Random.default_rng()) where {AT <: AbstractGPUArray, T}
-    rand_vec_dev = to_device(rand(rng, length(sys)), AT)
-    atoms_to_bump_dev = andersen_atoms_bump.(rand_vec_dev, sim.dt / thermostat.coupling_const,
-                                                            sys.virtual_site_flags)
-    atoms_to_leave_dev = one(T) .- atoms_to_bump_dev
-    vs = random_velocities(sys, thermostat.temperature; rng=rng)
-    sys.velocities .= sys.velocities .* atoms_to_leave_dev .+ vs .* atoms_to_bump_dev
+    backend = get_backend(sys.velocities)
+    kernel! = apply_Andersen_coupling_kernel!(backend)
+    kernel!(sys.velocities,sys.masses,  sys.k*thermostat.temperature,sim.dt / thermostat.coupling_const , sys.virtual_site_flags,ndrange=length(sys.velocities))
     return false
 end
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -649,9 +649,9 @@ end
 
 @kernel function random_velocities_kernel!(vels::AbstractVector{SVector{D, C}},@Const(masses::AbstractVector{M}), units, @Const(virtual_sites))  where {D,C,M}
     i = @index(Global, Linear)
-    if i<= length(vels)
+    if i<= length(vels) && !virtual_sites[i]
         @inbounds scale = C(sqrt(units/masses[i]))
-        @inbounds vels[i] = SVector{D,C}(randn() * scale,randn() * scale, randn() * scale)
+        @inbounds vels[i] = SVector{D, C}(ntuple(i -> randn() * scale, Val(D)))
     end
 end
 
@@ -660,4 +660,12 @@ function random_velocities!(vels::AbstractGPUArray, sys::Molly.AbstractSystem, t
     kernel! = random_velocities_kernel!(backend)
     kernel!(vels,sys.masses,  sys.k*temp, sys.virtual_site_flags,ndrange=length(vels))
     return vels 
+end
+
+@kernel function apply_Andersen_coupling_kernel!(velocities::AbstractVector{SVector{D, C}}, @Const(masses::AbstractVector{M}), units,val,@Const(virtual_sites)) where {D,C,M}
+    i = @index(Global, Linear)
+    @inbounds if i<= length(velocities) && !virtual_sites[i] && rand() < val
+        @inbounds scale = C(sqrt(units/masses[i]))
+        @inbounds velocities[i] = SVector{D, C}(ntuple(i -> randn() * scale, Val(D)))
+    end
 end

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -646,3 +646,18 @@ end
         end
     end
 end
+
+@kernel function random_velocities_kernel!(vels::AbstractVector{SVector{D, C}},@Const(masses::AbstractVector{M}), units, @Const(virtual_sites))  where {D,C,M}
+    i = @index(Global, Linear)
+    if i<= length(vels)
+        @inbounds scale = C(sqrt(units/masses[i]))
+        @inbounds vels[i] = SVector{D,C}(randn() * scale,randn() * scale, randn() * scale)
+    end
+end
+
+function random_velocities!(vels::AbstractGPUArray, sys::Molly.AbstractSystem, temp; rng)
+    backend = get_backend(vels)
+    kernel! = random_velocities_kernel!(backend)
+    kernel!(vels,sys.masses,  sys.k*temp, sys.virtual_site_flags,ndrange=length(vels))
+    return vels 
+end

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -649,9 +649,13 @@ end
 
 @kernel function random_velocities_kernel!(vels::AbstractVector{SVector{D, C}},@Const(masses::AbstractVector{M}), units, @Const(virtual_sites))  where {D,C,M}
     i = @index(Global, Linear)
-    if i<= length(vels) && !virtual_sites[i]
-        @inbounds scale = C(sqrt(units/masses[i]))
-        @inbounds vels[i] = SVector{D, C}(ntuple(i -> randn() * scale, Val(D)))
+    if i<= length(vels) 
+        @inbounds if !virtual_sites[i]
+            @inbounds scale = C(sqrt(units/masses[i]))
+            @inbounds vels[i] = SVector{D, C}(ntuple(i -> randn()* scale, Val(D)))
+        else
+            @inbounds velocities[i] = SVector{D, C}(ntuple(i -> 0.0, Val(D)))
+        end
     end
 end
 

--- a/test/gpu_consistency.jl
+++ b/test/gpu_consistency.jl
@@ -536,6 +536,61 @@
                 @test isapprox(energies[2], direct[2], rtol=1e-8, atol=1e-10u"kJ * mol^-1")
             end
         end
+
+        @testset "Langevin random numbers" begin
+            n_atoms = 50_000
+            boundary = CubicBoundary(50.0u"nm")
+
+            atom_mass = 10.0u"g/mol"
+            Q = Quantity{Float32, u"𝐋", typeof(u"nm")}
+            temp = 298.0u"K"
+            AT = CuArray
+            atoms = [Atom(mass=10.0f0u"g/mol", charge=0.0f0, σ=0.3f0u"nm", ϵ=0.1f0u"kJ * mol^-1") for i in 1:n_atoms]
+            coords = [SVector{3, Q}(1.0f0u"nm", 1.0f0u"nm", 1.0f0u"nm") for _ in 1:n_atoms]
+            velocities = [random_velocity(atom_mass, temp) for i in 1:n_atoms]
+            pairwise_inters = Tuple([LennardJones(;cutoff=Molly.DistanceCutoff(0.9f0u"nm"),use_neighbors=false)])
+
+            sys = System(
+                atoms=deepcopy(atoms),
+                coords=deepcopy(coords),
+                boundary=boundary,
+                velocities=deepcopy(velocities),
+                pairwise_inters=pairwise_inters,
+                loggers=(temp=TemperatureLogger(100),)
+            )
+
+            sys2 = System(
+                atoms=AT(atoms),
+                coords=AT(coords),
+                boundary=boundary,
+                velocities=AT(velocities),
+                pairwise_inters=pairwise_inters,
+                loggers=(temp=TemperatureLogger(100),),
+                #neighbor_finder=neighbor_finder,
+            )
+
+            using Random, Statistics
+
+            velocities_gpu = AT(velocities)
+
+            ### benchmark against cpu version
+            for temp in [200.0u"K",250.0u"K",298.0u"K"] 
+                vel=deepcopy(velocities)
+                Molly.random_velocities!(vel, sys, temp)
+                mean_cpu = mean(mean(vel))
+                std_cpu = mean( std(vel))
+
+                vel= Molly.random_velocities!(velocities_gpu, sys2, temp; rng=cuRAND.LibraryRNG())
+                mean_gpu = mean(mean(vel))
+                std_gpu = mean( std(vel))
+
+                @test abs(mean_cpu) < 0.005u"nm * ps^-1"
+                @test abs(mean_gpu) < 0.005u"nm * ps^-1"
+
+                @test 0.99 < abs(std_cpu/std_gpu) < 1.01
+            end
+
+        end
     else
         @warn "CUDA not functional, skipping GPU consistency tests"
     end

--- a/test/gpu_consistency.jl
+++ b/test/gpu_consistency.jl
@@ -569,8 +569,6 @@
                 #neighbor_finder=neighbor_finder,
             )
 
-            using Random, Statistics
-
             velocities_gpu = AT(velocities)
 
             ### benchmark against cpu version

--- a/test/gpu_consistency.jl
+++ b/test/gpu_consistency.jl
@@ -582,9 +582,9 @@
                 mean_gpu = mean(mean(vel))
                 std_gpu = mean( std(vel))
 
-                @test abs(mean_cpu) < 0.005u"nm * ps^-1"
-                @test abs(mean_gpu) < 0.005u"nm * ps^-1"
-
+                @test -0.005u"nm * ps^-1" <= mean_cpu <= 0.005u"nm * ps^-1"
+                @test -0.005u"nm * ps^-1" <= mean_gpu <= 0.005u"nm * ps^-1"
+                
                 @test 0.99 < abs(std_cpu/std_gpu) < 1.01
             end
 

--- a/test/gpu_consistency.jl
+++ b/test/gpu_consistency.jl
@@ -578,7 +578,7 @@
                 mean_cpu = mean(mean(vel))
                 std_cpu = mean( std(vel))
 
-                vel= Molly.random_velocities!(velocities_gpu, sys2, temp; rng=cuRAND.LibraryRNG())
+                vel= Molly.random_velocities!(velocities_gpu, sys2, temp;rng=Random.TaskLocalRNG())
                 mean_gpu = mean(mean(vel))
                 std_gpu = mean( std(vel))
 


### PR DESCRIPTION
I have added a CUDA kernel for random_velocities!()

Performance improvement has been measured for a dense LJ system with fixed average density that has been simulated with the  Langevin algorithm for varying number of particles and box sizes. Benchmarked on a NVIDIA GeForce RTX 4090 I get:

before changes: commit 0f19f896
simulation 0 took 1.884167053 for 100 atoms
simulation 2 took 1.780424146 for 400 atoms
simulation 4 took 2.333971938 for 1600 atoms
simulation 6 took 3.446783882 for 6400 atoms
simulation 8 took 8.438397874 for 25600 atoms
simulation 10 took 31.827900505 for 102400 atoms


random_velocities!: commit 92eba91d
simulation 0 took 1.235772652 for 100 atoms
simulation 2 took 1.212126355 for 400 atoms
simulation 4 took 1.446382735 for 1600 atoms
simulation 6 took 2.0191413 for 6400 atoms
simulation 8 took 3.58989918 for 25600 atoms
simulation 10 took 11.58562941 for 102400 atoms 