### PR TITLE
Minor PME CPU Improvements

### DIFF
--- a/src/interactions/ewald.jl
+++ b/src/interactions/ewald.jl
@@ -402,8 +402,8 @@ function PME(dist_cutoff, atoms, boundary; error_tol=0.0005, order=5,
         pc_sum, pc_abs2_sum = nothing, nothing
     end
 
-    fft_plan  = plan_fft!(charge_grid)
-    bfft_plan = plan_bfft!(charge_grid)
+    fft_plan  = plan_fft!(charge_grid; num_threads = n_threads)
+    bfft_plan = plan_bfft!(charge_grid; num_threads = n_threads)
     bsm_x = to_device(bsplines_moduli[1], AT)
     bsm_y = to_device(bsplines_moduli[2], AT)
     bsm_z = to_device(bsplines_moduli[3], AT)

--- a/src/interactions/ewald.jl
+++ b/src/interactions/ewald.jl
@@ -668,14 +668,6 @@ end
     end
 end
 
-@inline function ustrip_recip_box(recip_box)
-    return SVector(
-        ustrip.(recip_box[1]),
-        ustrip.(recip_box[2]),
-        ustrip.(recip_box[3]),
-    )
-end
-
 # Unit-stripped CPU kernel: avoids Unitful overhead on every grid point.
 @inline function recip_conv_inner_nou!(vir_nou, charge_grid::Array{Complex{T}, 3}, bsm_x, bsm_y, bsm_z,
                                        recip_box, mesh_dims, f_div_ϵr, factor, boxfactor,
@@ -788,7 +780,7 @@ function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buff
     α_u = ustrip(α)
     factor = T(π)^2 / α_u^2
     boxfactor = T(π) * ustrip(volume(boundary))
-    recip_box_u = ustrip_recip_box(recip_box)
+    recip_box_u = ustrip_vec.(recip_box)
     length_unit = unit(box_sides(boundary, 1))
     f_u = ustrip(energy_units * length_unit, f_div_ϵr)
     esum = zero(T)
@@ -810,7 +802,7 @@ function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buff
     α_u = ustrip(α)
     factor = T(π)^2 / α_u^2
     boxfactor = T(π) * ustrip(volume(boundary))
-    recip_box_u = ustrip_recip_box(recip_box)
+    recip_box_u = ustrip_vec.(recip_box)
     length_unit = unit(box_sides(boundary, 1))
     f_u = ustrip(energy_units * length_unit, f_div_ϵr)
     buffer .= zero(T)

--- a/src/interactions/ewald.jl
+++ b/src/interactions/ewald.jl
@@ -402,8 +402,14 @@ function PME(dist_cutoff, atoms, boundary; error_tol=0.0005, order=5,
         pc_sum, pc_abs2_sum = nothing, nothing
     end
 
-    fft_plan  = plan_fft!(charge_grid; num_threads = n_threads)
-    bfft_plan = plan_bfft!(charge_grid; num_threads = n_threads)
+    if AT <: AbstractGPUArray
+        fft_plan  = plan_fft!(charge_grid)
+        bfft_plan = plan_bfft!(charge_grid)
+    else
+        fft_plan  = plan_fft!(charge_grid; num_threads=n_threads)
+        bfft_plan = plan_bfft!(charge_grid; num_threads=n_threads)
+    end
+    
     bsm_x = to_device(bsplines_moduli[1], AT)
     bsm_y = to_device(bsplines_moduli[2], AT)
     bsm_z = to_device(bsplines_moduli[3], AT)

--- a/src/interactions/ewald.jl
+++ b/src/interactions/ewald.jl
@@ -674,51 +674,6 @@ end
     end
 end
 
-# Unit-stripped CPU kernel: avoids Unitful overhead on every grid point.
-@inline function recip_conv_inner_nou!(vir_nou, charge_grid::Array{Complex{T}, 3}, bsm_x, bsm_y, bsm_z,
-                                       recip_box, mesh_dims, f_div_ϵr, factor, boxfactor,
-                                       kx, ky, kz, ::Val{needs_vir}) where {T, needs_vir}
-    if iszero(kx) && iszero(ky) && iszero(kz)
-        return zero(T)
-    end
-    nx, ny, nz = mesh_dims
-    maxkx, maxky, maxkz = T(0.5)*(nx+1), T(0.5)*(ny+1), T(0.5)*(nz+1)
-    @inbounds begin
-        mx = (kx < maxkx ? kx : kx - nx)
-        mhx = mx * recip_box[1][1]
-        bx = boxfactor * bsm_x[kx+1]
-        my = (ky < maxky ? ky : ky - ny)
-        mhy = mx * recip_box[2][1] + my * recip_box[2][2]
-        by = bsm_y[ky+1]
-        mz = (kz < maxkz ? kz : kz - nz)
-        mhz = mx * recip_box[3][1] + my * recip_box[3][2] + mz * recip_box[3][3]
-        d1, d2 = reim(charge_grid[kz+1, ky+1, kx+1])
-        m2 = mhx^2 + mhy^2 + mhz^2
-        bz = bsm_z[kz+1]
-        denom = m2 * bx * by * bz
-        eterm = f_div_ϵr * exp(-factor * m2) / denom
-        charge_grid[kz+1, ky+1, kx+1] = Complex(d1*eterm, d2*eterm)
-        struct2 = d1^2 + d2^2
-
-        if needs_vir
-            Ek = eterm * struct2
-            invm2 = one(T) / m2
-            coeff = 2*one(T) * (one(T) + factor*m2) * invm2
-            gxx = 1 - coeff*mhx*mhx
-            gxy =   - coeff*mhx*mhy
-            gxz =   - coeff*mhx*mhz
-            gyy = 1 - coeff*mhy*mhy
-            gyz =   - coeff*mhy*mhz
-            gzz = 1 - coeff*mhz*mhz
-            G = SMatrix{3, 3, T}(gxx, gxy, gxz,
-                                 gxy, gyy, gyz,
-                                 gxz, gyz, gzz)
-            vir_nou .+= Ek .* G
-        end
-        return eterm * struct2
-    end
-end
-
 function recip_conv_inner!(vir_nou, charge_grid::AbstractArray{Complex{T}, 3}, bsm_x, bsm_y, bsm_z,
                            recip_box, mesh_dims, energy_units, f_div_ϵr, factor, boxfactor,
                            kx, ky, kz, ::Val{needs_vir},
@@ -782,35 +737,27 @@ function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buff
     if needs_vir
         buffer_virial[1] .= zero(T)
     end
-    # Strip units once; length unit cancels between α, recip_box, and volume.
-    α_u = ustrip(α)
-    factor = T(π)^2 / α_u^2
-    boxfactor = T(π) * ustrip(volume(boundary))
-    recip_box_u = ustrip_vec.(recip_box)
-    length_unit = unit(box_sides(boundary, 1))
-    f_u = ustrip(energy_units * length_unit, f_div_ϵr)
-    esum = zero(T)
+    factor = T(π)^2 / α^2
+    boxfactor = T(π) * volume(boundary)
+    esum = zero(T) * energy_units
     for kx in 0:(mesh_dims[1]-1), ky in 0:(mesh_dims[2]-1), kz in 0:(mesh_dims[3]-1)
-        esum += recip_conv_inner_nou!(buffer_virial[1], charge_grid, bsm_x, bsm_y, bsm_z,
-                            recip_box_u, mesh_dims, f_u, factor, boxfactor, kx, ky, kz,
-                            Val(needs_vir))
+        esum_val = recip_conv_inner!(buffer_virial[1], charge_grid, bsm_x, bsm_y, bsm_z, recip_box,
+                            mesh_dims, energy_units, f_div_ϵr, factor, boxfactor, kx, ky, kz,
+                            Val(needs_vir), Val(false))
+        esum += esum_val
     end
     if needs_vir
         # The mesh sums both k and -k, so the virial needs the same 1/2 as the energy.
         vir .+= buffer_virial[1] .* energy_units / 2
     end
-    return esum * energy_units / 2
+    return esum / 2
 end
 
 function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buffer,
                      bsm_x, bsm_y, bsm_z, recip_box, f_div_ϵr, α, mesh_dims, boundary, energy_units,
                      ::Val{n_threads}, ::Val{needs_vir}) where {T, n_threads, needs_vir}
-    α_u = ustrip(α)
-    factor = T(π)^2 / α_u^2
-    boxfactor = T(π) * ustrip(volume(boundary))
-    recip_box_u = ustrip_vec.(recip_box)
-    length_unit = unit(box_sides(boundary, 1))
-    f_u = ustrip(energy_units * length_unit, f_div_ϵr)
+    factor = T(π)^2 / α^2
+    boxfactor = T(π) * volume(boundary)
     buffer .= zero(T)
     Threads.@threads for chunk_i in 1:n_threads
         if needs_vir
@@ -818,9 +765,10 @@ function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buff
         end
         for kx in (chunk_i-1):n_threads:(mesh_dims[1]-1)
             for ky in 0:(mesh_dims[2]-1), kz in 0:(mesh_dims[3]-1)
-                buffer[chunk_i] += recip_conv_inner_nou!(buffer_virial[chunk_i], charge_grid,
-                            bsm_x, bsm_y, bsm_z, recip_box_u, mesh_dims, f_u, factor, boxfactor,
-                            kx, ky, kz, Val(needs_vir))
+                esum_val = recip_conv_inner!(buffer_virial[chunk_i], charge_grid, bsm_x, bsm_y,
+                            bsm_z, recip_box, mesh_dims, energy_units, f_div_ϵr, factor, boxfactor,
+                            kx, ky, kz, Val(needs_vir), Val(false))
+                buffer[chunk_i] += ustrip(energy_units, esum_val)
             end
         end
     end

--- a/src/interactions/ewald.jl
+++ b/src/interactions/ewald.jl
@@ -604,12 +604,16 @@ end
     @inbounds x0index, y0index, z0index = grid_indices[1, i], grid_indices[2, i], grid_indices[3, i]
     @inbounds for ix in 0:(order-1)
         xindex = (x0index + ix) % mesh_dims[1]
+        θx = bsplines_θ[(i-1)*order+ix+1, 1]
+        qx = q * θx
         for iy in 0:(order-1)
             yindex = (y0index + iy) % mesh_dims[2]
+            θy = bsplines_θ[(i-1)*order+iy+1, 2]
+            qxy = qx * θy
             for iz in 0:(order-1)
                 zindex = (z0index + iz) % mesh_dims[3]
-                cb = q * bsplines_θ[(i-1)*order+ix+1, 1] *
-                            bsplines_θ[(i-1)*order+iy+1, 2] * bsplines_θ[(i-1)*order+iz+1, 3]
+                θz = bsplines_θ[(i-1)*order+iz+1, 3]
+                cb = qxy * θz
                 add_charge_grid!(charge_grid, zindex + 1, yindex + 1, xindex + 1, cb, Val(atomic))
             end
         end
@@ -661,6 +665,59 @@ end
     if i <= length(atoms)
         spread_charge_inner!(charge_grid_real, grid_indices, bsplines_θ, mesh_dims, order, atoms,
                              scheduler, i, Val(T), Val(true))
+    end
+end
+
+@inline function ustrip_recip_box(recip_box)
+    return SVector(
+        ustrip.(recip_box[1]),
+        ustrip.(recip_box[2]),
+        ustrip.(recip_box[3]),
+    )
+end
+
+# Unit-stripped CPU kernel: avoids Unitful overhead on every grid point.
+@inline function recip_conv_inner_nou!(vir_nou, charge_grid::Array{Complex{T}, 3}, bsm_x, bsm_y, bsm_z,
+                                       recip_box, mesh_dims, f_div_ϵr, factor, boxfactor,
+                                       kx, ky, kz, ::Val{needs_vir}) where {T, needs_vir}
+    if iszero(kx) && iszero(ky) && iszero(kz)
+        return zero(T)
+    end
+    nx, ny, nz = mesh_dims
+    maxkx, maxky, maxkz = T(0.5)*(nx+1), T(0.5)*(ny+1), T(0.5)*(nz+1)
+    @inbounds begin
+        mx = (kx < maxkx ? kx : kx - nx)
+        mhx = mx * recip_box[1][1]
+        bx = boxfactor * bsm_x[kx+1]
+        my = (ky < maxky ? ky : ky - ny)
+        mhy = mx * recip_box[2][1] + my * recip_box[2][2]
+        by = bsm_y[ky+1]
+        mz = (kz < maxkz ? kz : kz - nz)
+        mhz = mx * recip_box[3][1] + my * recip_box[3][2] + mz * recip_box[3][3]
+        d1, d2 = reim(charge_grid[kz+1, ky+1, kx+1])
+        m2 = mhx^2 + mhy^2 + mhz^2
+        bz = bsm_z[kz+1]
+        denom = m2 * bx * by * bz
+        eterm = f_div_ϵr * exp(-factor * m2) / denom
+        charge_grid[kz+1, ky+1, kx+1] = Complex(d1*eterm, d2*eterm)
+        struct2 = d1^2 + d2^2
+
+        if needs_vir
+            Ek = eterm * struct2
+            invm2 = one(T) / m2
+            coeff = 2*one(T) * (one(T) + factor*m2) * invm2
+            gxx = 1 - coeff*mhx*mhx
+            gxy =   - coeff*mhx*mhy
+            gxz =   - coeff*mhx*mhz
+            gyy = 1 - coeff*mhy*mhy
+            gyz =   - coeff*mhy*mhz
+            gzz = 1 - coeff*mhz*mhz
+            G = SMatrix{3, 3, T}(gxx, gxy, gxz,
+                                 gxy, gyy, gyz,
+                                 gxz, gyz, gzz)
+            vir_nou .+= Ek .* G
+        end
+        return eterm * struct2
     end
 end
 
@@ -727,27 +784,35 @@ function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buff
     if needs_vir
         buffer_virial[1] .= zero(T)
     end
-    factor = T(π)^2 / α^2
-    boxfactor = T(π) * volume(boundary)
-    esum = zero(T) * energy_units
+    # Strip units once; length unit cancels between α, recip_box, and volume.
+    α_u = ustrip(α)
+    factor = T(π)^2 / α_u^2
+    boxfactor = T(π) * ustrip(volume(boundary))
+    recip_box_u = ustrip_recip_box(recip_box)
+    length_unit = unit(box_sides(boundary, 1))
+    f_u = ustrip(energy_units * length_unit, f_div_ϵr)
+    esum = zero(T)
     for kx in 0:(mesh_dims[1]-1), ky in 0:(mesh_dims[2]-1), kz in 0:(mesh_dims[3]-1)
-        esum_val = recip_conv_inner!(buffer_virial[1], charge_grid, bsm_x, bsm_y, bsm_z, recip_box,
-                            mesh_dims, energy_units, f_div_ϵr, factor, boxfactor, kx, ky, kz,
-                            Val(needs_vir), Val(false))
-        esum += esum_val
+        esum += recip_conv_inner_nou!(buffer_virial[1], charge_grid, bsm_x, bsm_y, bsm_z,
+                            recip_box_u, mesh_dims, f_u, factor, boxfactor, kx, ky, kz,
+                            Val(needs_vir))
     end
     if needs_vir
         # The mesh sums both k and -k, so the virial needs the same 1/2 as the energy.
         vir .+= buffer_virial[1] .* energy_units / 2
     end
-    return esum / 2
+    return esum * energy_units / 2
 end
 
 function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buffer,
                      bsm_x, bsm_y, bsm_z, recip_box, f_div_ϵr, α, mesh_dims, boundary, energy_units,
                      ::Val{n_threads}, ::Val{needs_vir}) where {T, n_threads, needs_vir}
-    factor = T(π)^2 / α^2
-    boxfactor = T(π) * volume(boundary)
+    α_u = ustrip(α)
+    factor = T(π)^2 / α_u^2
+    boxfactor = T(π) * ustrip(volume(boundary))
+    recip_box_u = ustrip_recip_box(recip_box)
+    length_unit = unit(box_sides(boundary, 1))
+    f_u = ustrip(energy_units * length_unit, f_div_ϵr)
     buffer .= zero(T)
     Threads.@threads for chunk_i in 1:n_threads
         if needs_vir
@@ -755,10 +820,9 @@ function recip_conv!(vir, buffer_virial, charge_grid::Array{Complex{T}, 3}, buff
         end
         for kx in (chunk_i-1):n_threads:(mesh_dims[1]-1)
             for ky in 0:(mesh_dims[2]-1), kz in 0:(mesh_dims[3]-1)
-                esum_val = recip_conv_inner!(buffer_virial[chunk_i], charge_grid, bsm_x, bsm_y,
-                            bsm_z, recip_box, mesh_dims, energy_units, f_div_ϵr, factor, boxfactor,
-                            kx, ky, kz, Val(needs_vir), Val(false))
-                buffer[chunk_i] += ustrip(energy_units, esum_val)
+                buffer[chunk_i] += recip_conv_inner_nou!(buffer_virial[chunk_i], charge_grid,
+                            bsm_x, bsm_y, bsm_z, recip_box_u, mesh_dims, f_u, factor, boxfactor,
+                            kx, ky, kz, Val(needs_vir))
             end
         end
     end
@@ -820,13 +884,16 @@ function interpolate_force_inner!(Fs, charge_grid, grid_indices, bsplines_θ,
             for iy in 0:(order-1)
                 yindex = (y0index + iy) % mesh_dims[2]
                 ty, dty = bsplines_θ[(i-1)*order+iy+1, 2], bsplines_dθ[(i-1)*order+iy+1, 2]
+                dtx_ty = dtx * ty
+                tx_dty = tx * dty
+                txy = tx * ty
                 for iz in 0:(order-1)
                     zindex = (z0index + iz) % mesh_dims[3]
                     tz, dtz = bsplines_θ[(i-1)*order+iz+1, 3], bsplines_dθ[(i-1)*order+iz+1, 3]
                     gridvalue = real(charge_grid[zindex+1, yindex+1, xindex+1])
-                    fx += dtx * ty * tz * gridvalue
-                    fy += tx * dty * tz * gridvalue
-                    fz += tx * ty * dtz * gridvalue
+                    fx += dtx_ty * tz * gridvalue
+                    fy += tx_dty * tz * gridvalue
+                    fz += txy * dtz * gridvalue
                 end
             end
         end


### PR DESCRIPTION
Looked for some quick changes to speed up PME on CPU. The `ustrip` optimization probably could be used for the GPU path as well. I just don't have any easy way to test that right now. I do not really see any way to improve the k-space as that just calls FFTW. On the real-space side I made the following changes:

1. `ustrip` `α`, volume, `recip_box`, and `f/ϵr` once outside the k-space loop, and run convolution without units. Apply units at the end.
2. Hoisted some calculations in charge spreading and force interpolation. This probably has modest improvements, but it was definitely wasted FLOPs.
3. Pass `num_threads` to fft plans (EDIT)

### Result (6mrr, ~16k atoms, 4 Julia threads)
Timing `Molly.ewald_pe_forces!` only, 1000 iterations after warmup:

≈ **16% faster** on the PME energy+forces path single thread

### Benchmark Code
```julia
using Molly

n_threads = 1
ff = MolecularForceField(
    Float64,
    joinpath(pkgdir(Molly), "data", "force_fields", "ff99SBildn.xml"),
    joinpath(pkgdir(Molly), "data", "force_fields", "tip3p_standard.xml"),
)
sys = System(
    joinpath(pkgdir(Molly), "data", "6mrr_equil.pdb"),
    ff;
    array_type=Array,
    nonbonded_method=:pme,
    center_coords=false,
)
pme = only(filter(i -> i isa PME, sys.general_inters))
Fs = Molly.zero_forces(sys)

# warmup
for _ in 1:3
    fill!(Fs, zero(eltype(Fs)))
    Molly.ewald_pe_forces!(Fs, nothing, sys, pme, Val(false); n_threads=n_threads)
end

n = 1000
samples_ms = Vector{Float64}(undef, n)
for i in 1:n
    fill!(Fs, zero(eltype(Fs)))
    t0 = time_ns()
    Molly.ewald_pe_forces!(Fs, nothing, sys, pme, Val(false); n_threads=n_threads)
    samples_ms[i] = (time_ns() - t0) / 1e6
end
μ = sum(samples_ms) / n
se = sqrt(sum((x - μ)^2 for x in samples_ms) / (n - 1)) / sqrt(n)
println("ms / ewald_pe_forces! = $(round(μ; digits=3)) ± $(round(se; digits=3))")
```