### PR TITLE
Use philox hash for DPD random force

### DIFF
--- a/src/interactions/dpd.jl
+++ b/src/interactions/dpd.jl
@@ -1,7 +1,7 @@
 export DPDInteraction
 
 @doc raw"""
-    DPDInteraction(; a, γ, σ, r_c, dt, use_neighbors)
+    DPDInteraction(; a, γ, σ, r_c, dt, use_neighbors, key)
 
 The dissipative particle dynamics (DPD) interaction between two particles.
 
@@ -39,8 +39,8 @@ The conservative potential energy is
 V(r_{ij}) = \frac{a}{2} r_c \left(1 - \frac{r_{ij}}{r_c}\right)^2
 ```
 
-Deterministic pairwise random numbers are generated from a hash of the key argument,
-the particle indices, and the step number, ensuring momentum conservation and reproducibility.
+Pairwise random numbers are generated from a hash of the `key`,
+the particle indices, and the step number, ensuring momentum conservation.
 
 When using a neighbor list, set `dist_cutoff` to at least `1.5 * r_c` to provide a
 skin distance that accounts for particle movement between neighbor list rebuilds.
@@ -52,7 +52,7 @@ skin distance that accounts for particle movement between neighbor list rebuilds
 - `r_c`: the cutoff distance beyond which all forces are zero.
 - `dt`: the simulation timestep (needed for random force scaling as Δt⁻¹ᐟ²).
 - `use_neighbors::Bool=true`: whether to use the neighbor list.
-- `key::UInt64=0x6c6a2e796c6c6f4d`: Change this to get different random forces.
+- `key::UInt64=rand(UInt64)`: the seed for the random forces.
 """
 @kwdef struct DPDInteraction{A, G, S, R, D} <: PairwiseInteraction
     a::A = 25.0
@@ -61,7 +61,7 @@ skin distance that accounts for particle movement between neighbor list rebuilds
     r_c::R = 1.0
     dt::D = 0.01
     use_neighbors::Bool = false
-    key::UInt64 = 0x6c6a2e796c6c6f4d # reinterpret(UInt64, b"Molly.jl")[1]
+    key::UInt64 = rand(UInt64)
 end
 
 use_neighbors(inter::DPDInteraction) = inter.use_neighbors
@@ -78,11 +78,11 @@ end
 
 # Deterministic per-pair Gaussian noise via hash-based Box-Muller transform.
 # Symmetric in (i, j) to ensure momentum conservation.
-@inline function dpd_gaussian(idx_i::UInt32, idx_j::UInt32, step_n::UInt64, key::UInt64)::Float32
-    a, b = minmax(idx_i, idx_j)
+@inline function dpd_gaussian(idx_i::Integer, idx_j::Integer, step_n::Integer, key::Integer)::Float32
+    a, b = minmax(idx_i%UInt32, idx_j%UInt32)
     # Assuming < 2^30 atoms this should not conflict with the Langevin stream
     # To be extra safe a different key can be used.
-    randn_f32(UInt64(b)<<32 | UInt64(a), step_n, key)[1]
+    randn_f32(UInt64(b)<<32 | UInt64(a), step_n%UInt64, key%UInt64)[1]
 end
 
 @inline function force(inter::DPDInteraction{A},
@@ -117,7 +117,7 @@ end
     f_D = inter.γ * w_D * rdotv
 
     # Random: pairwise-correlated stochastic force
-    ξ = A(dpd_gaussian(atom_i.index%UInt32, atom_j.index%UInt32, step_n%UInt64, inter.key))
+    ξ = A(dpd_gaussian(atom_i.index, atom_j.index, step_n, inter.key))
     f_R = inter.σ * w_R * ξ * inv(sqrt(inter.dt)) * inv_r
 
     return (f_C + f_D + f_R) * dr

--- a/src/interactions/dpd.jl
+++ b/src/interactions/dpd.jl
@@ -39,8 +39,8 @@ The conservative potential energy is
 V(r_{ij}) = \frac{a}{2} r_c \left(1 - \frac{r_{ij}}{r_c}\right)^2
 ```
 
-Deterministic pairwise random numbers are generated from a hash of the particle
-indices and the step number, ensuring momentum conservation and reproducibility.
+Deterministic pairwise random numbers are generated from a hash of the key argument,
+the particle indices, and the step number, ensuring momentum conservation and reproducibility.
 
 When using a neighbor list, set `dist_cutoff` to at least `1.5 * r_c` to provide a
 skin distance that accounts for particle movement between neighbor list rebuilds.
@@ -52,6 +52,7 @@ skin distance that accounts for particle movement between neighbor list rebuilds
 - `r_c`: the cutoff distance beyond which all forces are zero.
 - `dt`: the simulation timestep (needed for random force scaling as Δt⁻¹ᐟ²).
 - `use_neighbors::Bool=true`: whether to use the neighbor list.
+- `key::UInt64=0x6c6a2e796c6c6f4d`: Change this to get different random forces.
 """
 @kwdef struct DPDInteraction{A, G, S, R, D} <: PairwiseInteraction
     a::A = 25.0
@@ -60,6 +61,7 @@ skin distance that accounts for particle movement between neighbor list rebuilds
     r_c::R = 1.0
     dt::D = 0.01
     use_neighbors::Bool = false
+    key::UInt64 = 0x6c6a2e796c6c6f4d # reinterpret(UInt64, b"Molly.jl")[1]
 end
 
 use_neighbors(inter::DPDInteraction) = inter.use_neighbors
@@ -76,13 +78,11 @@ end
 
 # Deterministic per-pair Gaussian noise via hash-based Box-Muller transform.
 # Symmetric in (i, j) to ensure momentum conservation.
-@inline function dpd_gaussian(idx_i::Integer, idx_j::Integer, step_n::Integer,
-                              ::Val{T}=Val(Float64)) where T
+@inline function dpd_gaussian(idx_i::UInt32, idx_j::UInt32, step_n::UInt64, key::UInt64)::Float32
     a, b = minmax(idx_i, idx_j)
-    h = hash((a, b, step_n))
-    u1 = (h & 0xFFFFFFFF) / T(4294967296.0)
-    u2 = ((h >> 32) & 0xFFFFFFFF) / T(4294967296.0)
-    return sqrt(-2 * log(u1 + T(1e-30))) * cos(2 * T(π) * u2)
+    # Assuming < 2^30 atoms this should not conflict with the Langevin stream
+    # To be extra safe a different key can be used.
+    randn_f32(UInt64(b)<<32 | UInt64(a), step_n, key)[1]
 end
 
 @inline function force(inter::DPDInteraction{A},
@@ -117,7 +117,7 @@ end
     f_D = inter.γ * w_D * rdotv
 
     # Random: pairwise-correlated stochastic force
-    ξ = dpd_gaussian(atom_i.index, atom_j.index, step_n, Val(A))
+    ξ = A(dpd_gaussian(atom_i.index%UInt32, atom_j.index%UInt32, step_n%UInt64, inter.key))
     f_R = inter.σ * w_R * ξ * inv(sqrt(inter.dt)) * inv_r
 
     return (f_C + f_D + f_R) * dr

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -1828,20 +1828,20 @@ end
 
     # Random noise symmetry: dpd_gaussian is symmetric in particle indices
     for step in 1:10
-        @test Molly.dpd_gaussian(1%UInt32, 2%UInt32, step%UInt64, 1%UInt64) == Molly.dpd_gaussian(2%UInt32, 1%UInt32, step%UInt64, 1%UInt64)
-        @test Molly.dpd_gaussian(5%UInt32, 13%UInt32, step%UInt64, 1%UInt64) == Molly.dpd_gaussian(13%UInt32, 5%UInt32, step%UInt64, 1%UInt64)
+        @test Molly.dpd_gaussian(1, 2, step, 1) == Molly.dpd_gaussian(2, 1, step, 1)
+        @test Molly.dpd_gaussian(5, 13, step, 1) == Molly.dpd_gaussian(13, 5, step, 1)
     end
 
     # Random noise has the correct covariance
     N = 100000
     covar = cov([
-        [Molly.dpd_gaussian(1%UInt32, 2%UInt32, s%UInt64, 1%UInt64) for s in 1:N];;
-        [Molly.dpd_gaussian(1%UInt32, 3%UInt32, s%UInt64, 1%UInt64) for s in 1:N];;
-        [Molly.dpd_gaussian(1%UInt32, 2%UInt32, s%UInt64, 2%UInt64) for s in 1:N];;
-        [Molly.dpd_gaussian(s%UInt32, 1%UInt32, 1%UInt64, 2%UInt64) for s in 5:N+4];;
-        [Molly.dpd_gaussian(s%UInt32, 2%UInt32, 1%UInt64, 2%UInt64) for s in 5:N+4];;
-        [Molly.dpd_gaussian(s%UInt32, 10000000%UInt32, 1%UInt64, 2%UInt64) for s in 1:N];;
-        [Molly.dpd_gaussian(s%UInt32, 10000001%UInt32, 1%UInt64, 2%UInt64) for s in 1:N];;
+        [Molly.dpd_gaussian(1, 2, s, 1) for s in 1:N];;
+        [Molly.dpd_gaussian(1, 3, s, 1) for s in 1:N];;
+        [Molly.dpd_gaussian(1, 2, s, 2) for s in 1:N];;
+        [Molly.dpd_gaussian(s, 1, 1, 2) for s in 5:N+4];;
+        [Molly.dpd_gaussian(s, 2, 1, 2) for s in 5:N+4];;
+        [Molly.dpd_gaussian(s, 10000000, 1, 2) for s in 1:N];;
+        [Molly.dpd_gaussian(s, 10000001, 1, 2) for s in 1:N];;
     ])
     for i in 1:size(covar, 1)
         for j in 1:size(covar, 2)

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -1828,11 +1828,28 @@ end
 
     # Random noise symmetry: dpd_gaussian is symmetric in particle indices
     for step in 1:10
-        @test Molly.dpd_gaussian(1, 2, step) == Molly.dpd_gaussian(2, 1, step)
-        @test Molly.dpd_gaussian(5, 13, step) == Molly.dpd_gaussian(13, 5, step)
+        @test Molly.dpd_gaussian(1%UInt32, 2%UInt32, step%UInt64, 1%UInt64) == Molly.dpd_gaussian(2%UInt32, 1%UInt32, step%UInt64, 1%UInt64)
+        @test Molly.dpd_gaussian(5%UInt32, 13%UInt32, step%UInt64, 1%UInt64) == Molly.dpd_gaussian(13%UInt32, 5%UInt32, step%UInt64, 1%UInt64)
     end
 
-    # Random noise varies with step number
-    vals = [Molly.dpd_gaussian(1, 2, s) for s in 1:100]
-    @test std(vals) > 0.5
+    # Random noise has the correct covariance
+    N = 100000
+    covar = cov([
+        [Molly.dpd_gaussian(1%UInt32, 2%UInt32, s%UInt64, 1%UInt64) for s in 1:N];;
+        [Molly.dpd_gaussian(1%UInt32, 3%UInt32, s%UInt64, 1%UInt64) for s in 1:N];;
+        [Molly.dpd_gaussian(1%UInt32, 2%UInt32, s%UInt64, 2%UInt64) for s in 1:N];;
+        [Molly.dpd_gaussian(s%UInt32, 1%UInt32, 1%UInt64, 2%UInt64) for s in 5:N+4];;
+        [Molly.dpd_gaussian(s%UInt32, 2%UInt32, 1%UInt64, 2%UInt64) for s in 5:N+4];;
+        [Molly.dpd_gaussian(s%UInt32, 10000000%UInt32, 1%UInt64, 2%UInt64) for s in 1:N];;
+        [Molly.dpd_gaussian(s%UInt32, 10000001%UInt32, 1%UInt64, 2%UInt64) for s in 1:N];;
+    ])
+    for i in 1:size(covar, 1)
+        for j in 1:size(covar, 2)
+            if i == j
+                @test abs(covar[i, j] - 1.0) < 0.02
+            else
+                @test abs(covar[i, j]) < 0.02
+            end
+        end
+    end
 end

--- a/test/interactions.jl
+++ b/test/interactions.jl
@@ -1761,14 +1761,14 @@ end
 end
 
 @testset "DPD interaction" begin
-    r_c = 1.0
+    r_c = 2.5
     a_param = 25.0
     γ_param = 4.5
     dt = 0.01
     σ_param = 3.0
-    boundary = CubicBoundary(5.0)
+    boundary = CubicBoundary(10.0)
 
-    inter = DPDInteraction(a=a_param, γ=γ_param, σ=σ_param, r_c=r_c, dt=dt)
+    inter = DPDInteraction(a=a_param, γ=γ_param, σ=σ_param, r_c=r_c, dt=dt, key=UInt64(1))
 
     @test !use_neighbors(inter)
     @test use_neighbors(DPDInteraction(use_neighbors=true))
@@ -1782,31 +1782,32 @@ end
     dr = vector(c1, c2, boundary)
     r = norm(dr)
 
-    # Conservative force only (zero velocities, deterministic random from hash)
-    f = force(inter, dr, a1, a2, NoUnits, false, c1, c2, boundary, v1, v2, 0)
+    # Conservative force only (zero velocities and σ = 0 so no random force)
+    inter_cons = DPDInteraction(a=a_param, γ=γ_param, σ=0.0, r_c=r_c, dt=dt)
+    f = force(inter_cons, dr, a1, a2, NoUnits, false, c1, c2, boundary, v1, v2, 0)
     w_R = 1 - r / r_c
     f_C_expected = a_param * w_R / r
     # The force should be in the +x direction (repulsive, pushing j away from i)
+    @test isapprox(f, f_C_expected * dr; atol=1e-10)
     @test f[1] > 0.0
-    @test isapprox(f[2], 0.0; atol=1e-10)
-    @test isapprox(f[3], 0.0; atol=1e-10)
 
     # Conservative potential energy
-    pe = potential_energy(inter, dr, a1, a2, NoUnits)
+    pe = potential_energy(inter_cons, dr, a1, a2, NoUnits)
     pe_expected = (a_param / 2) * r_c * w_R^2
     @test isapprox(pe, pe_expected; atol=1e-10)
 
     # Force is zero at and beyond cutoff
-    c3 = SVector(2.0, 1.0, 1.0)
+    c3 = SVector(3.5, 1.0, 1.0)
     dr_cutoff = vector(c1, c3, boundary)
     f_cutoff = force(inter, dr_cutoff, a1, a2, NoUnits, false, c1, c3, boundary, v1, v2, 0)
-    @test all(isapprox.(f_cutoff, 0.0; atol=1e-10))
-    @test isapprox(potential_energy(inter, dr_cutoff, a1, a2, NoUnits), 0.0; atol=1e-10)
+    @test iszero(f_cutoff)
+    @test iszero(potential_energy(inter, dr_cutoff, a1, a2, NoUnits))
 
-    c4 = SVector(2.5, 1.0, 1.0)
+    c4 = SVector(4.0, 1.0, 1.0)
     dr_beyond = vector(c1, c4, boundary)
     f_beyond = force(inter, dr_beyond, a1, a2, NoUnits, false, c1, c4, boundary, v1, v2, 0)
-    @test all(isapprox.(f_beyond, 0.0; atol=1e-10))
+    @test iszero(f_beyond)
+    @test iszero(potential_energy(inter, dr_beyond, a1, a2, NoUnits))
 
     # Dissipative force: approaching particles should experience damping
     v1_approach = SVector(1.0, 0.0, 0.0)
@@ -1825,6 +1826,18 @@ end
     f_diss_recede = force(inter_nodiss, dr, a1, a2, NoUnits, false, c1, c2, boundary,
                           v1_recede, v2_still, 0)
     @test f_diss_recede[1] < 0.0
+
+    # With all terms included the pair forces are equal and opposite and act
+    # along the line of centers, conserving linear and angular momentum
+    c5 = SVector(1.2, 1.3, 1.6)
+    v5 = SVector(0.5, -0.2, 0.1)
+    v6 = SVector(-0.3, 0.4, 0.2)
+    dr_gen = vector(c1, c5, boundary)
+    f_ij = force(inter, dr_gen , a1, a2, NoUnits, false, c1, c5, boundary, v5, v6, 7)
+    f_ji = force(inter, -dr_gen, a2, a1, NoUnits, false, c5, c1, boundary, v6, v5, 7)
+    @test f_ij == -f_ji
+    @test !iszero(f_ij)
+    @test isapprox(abs(dot(f_ij, dr_gen)), norm(f_ij)*norm(dr_gen); atol=1e-10)
 
     # Random noise symmetry: dpd_gaussian is symmetric in particle indices
     for step in 1:10


### PR DESCRIPTION
This PR fixes #275 by using the `randn_f32` from PhiloxRNG.jl instead of `Base.hash` which was not designed to have good statistical properties.

This PR also adds a `key` field to the `DPDInteraction` struct to change the random forces.

Using philox4x32_10 here is not ideal because it generates four random values when only one is needed. It is still reasonably fast, but there is probably room for improvement.

CC @sivasathyaseeelan 