### PR TITLE
Avoids using Dispersion Correction when Custom Nonbonded forces are used

### DIFF
--- a/src/force_field.jl
+++ b/src/force_field.jl
@@ -629,11 +629,11 @@ function read_ff_xml!(ff_file, ff_param_array, atom_types, atom_type_order, attr
         elseif entry_name == "NonbondedForce"
             if haskey(entry, "useDispersionCorrection")
                 dispersion_correction = parse(Bool, lowercase(entry["useDispersionCorrection"]))
-                if !isnothing(ff_param_array[8]) && dispersion_correction != ff_param_array[8]
+                if !isnothing(ff_param_array[12]) && dispersion_correction != ff_param_array[12]
                     error("multiple NonbondedForce/LennardJonesForce entries with " *
                           "different useDispersionCorrection")
                 end
-                ff_param_array[8] = dispersion_correction
+                ff_param_array[12] = dispersion_correction
             end
             if haskey(entry, "coulomb14scale")
                 w = parse(T, entry["coulomb14scale"])
@@ -740,6 +740,7 @@ function read_ff_xml!(ff_file, ff_param_array, atom_types, atom_type_order, attr
         elseif entry_name == "CustomNonbondedForce"
             dexp_definition = "sqrt(epsilon1*epsilon2)*(((beta*exp(alpha))/(alpha-beta))*exp(-alpha*(r/((2^(1/6))*((sigma1+sigma2)/2))))-((alpha*exp(beta))/(alpha-beta))*exp(-beta*(r/((2^(1/6))*((sigma1+sigma2)/2)))))"
             if entry["energy"] == dexp_definition && entry["bondCutoff"] == "3"
+                ff_param_array[13] = true
                 for element in eachelement(entry)
                     if element.name == "GlobalParameter"
                         if element["name"] == "alpha"
@@ -840,6 +841,7 @@ struct MolecularForceField{T, G, NB, M, D, DA, E, K, KA, C}
     weight_14_lj::T
     global_params::G
     dispersion_correction::Bool
+    custom_nonbonded::Bool
     nbfix_pairs::NB
     attributes_from_residue::Vector{String}
     residue_name_replacements::Dict{String,String}
@@ -875,12 +877,12 @@ function MolecularForceField(T::Type, ff_files::AbstractString...; units::Bool=t
     # weight_14_coulomb, weight_14_coulomb_set, weight_14_lj, weight_14_lj_set,
     # weight_14_lj_ljforce, weight_14_lj_ljforce_set, 
     # double_exp_alpha, dexp_alpha_set, double_exp_beta, dexp_beta_set, 
-    # dispersion_correction
+    # dispersion_correction, custom_nonbonded_set
     ff_param_array = ["",
                       one(T), false, one(T), false, 
                       one(T), false, 
                       zero(T), false, zero(T), false,
-                      nothing]
+                      nothing, false]
     attributes_from_residue = String[]
     residues = Dict{String, ResidueTemplate}()
     patches = Dict{String, ResiduePatchTemplate}()
@@ -905,11 +907,14 @@ function MolecularForceField(T::Type, ff_files::AbstractString...; units::Bool=t
     weight_14_coulomb = ff_param_array[2]
     # Use LennardJonesForce 1-4 weighting if present
     weight_14_lj = (ff_param_array[7] ? ff_param_array[6] : ff_param_array[4])
-    dispersion_correction = (isnothing(ff_param_array[12]) ? true : ff_param_array[12])
+    dispersion_correction = if isnothing(ff_param_array[12])
+        !ff_param_array[13]
+    else
+        ff_param_array[12]
+    end
 
-    has_double_exp_params = ff_param_array[9] && ff_param_array[11]
-    double_exp_alpha = (has_double_exp_params ? ff_param_array[8] : zero(T))
-    double_exp_beta  = (has_double_exp_params ? ff_param_array[10] : zero(T))
+    double_exp_alpha = (ff_param_array[9] ? ff_param_array[8] : zero(T))
+    double_exp_beta  = (ff_param_array[11] ? ff_param_array[10] : zero(T))
 
     global_params = [double_exp_alpha, double_exp_beta]
     G = typeof(global_params)
@@ -1144,7 +1149,7 @@ function MolecularForceField(T::Type, ff_files::AbstractString...; units::Bool=t
     return MolecularForceField{T, G, NB, M, D, DA, E, K, KA, IC}(
         atom_types, atom_type_order, residues, torsion_order, weight_14_coulomb, weight_14_lj,
         global_params,
-        dispersion_correction, nbfix_pairs_conc, attributes_from_residue, resname_replacements,
+        dispersion_correction, ff_param_array[13], nbfix_pairs_conc, attributes_from_residue, resname_replacements,
         atomname_replacements, standard_bonds, type_to_class, class_to_types, bond_resolver,
         angle_resolver, torsion_resolver, cmap_resolver,
     )

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -555,12 +555,17 @@ function System(coord_file::AbstractString,
     if isnothing(dispersion_correction)
         disp_corr = force_field.dispersion_correction
     else
+        disp_corr = dispersion_correction
+    end
+    if disp_corr && force_field.custom_nonbonded
+        throw(ArgumentError("dispersion_correction=true is not supported with CustomNonbondedForce"))
+    end
+    if !isnothing(dispersion_correction)
         if dispersion_correction != force_field.dispersion_correction
             err_str = "dispersion_correction is $dispersion_correction but value in the force " *
                       "field is $(force_field.dispersion_correction), using $dispersion_correction"
             report_issue(err_str, strictness)
         end
-        disp_corr = dispersion_correction
     end
     dist_neighbors = dist_cutoff + dist_buffer
     T = typeof(force_field.weight_14_coulomb)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -462,6 +462,22 @@ end
     end
 end
 
+@testset "Force field XML options" begin
+    ff_garnet = MolecularForceField(joinpath(ff_dir, "ethanol_garnet.xml"); units=false)
+    @test ff_garnet.dispersion_correction == false
+    @test ff_garnet.custom_nonbonded == true
+    @test ff_garnet.global_params == [12.159626, 4.326311]
+    @test_throws ArgumentError System(
+        joinpath(data_dir, "ethanol_garnet.pdb"),
+        ff_garnet;
+        units=false,
+        dispersion_correction=true,
+    )
+
+    ff_tip3p = MolecularForceField(joinpath(ff_dir, "tip3p_standard.xml"); units=false)
+    @test ff_tip3p.custom_nonbonded == false
+end
+
 @testset "Double exponential force field setup" begin
     ff = MolecularForceField(
         joinpath(ff_dir, "ethanol_garnet.xml");
@@ -472,7 +488,6 @@ end
         ff;
         nonbonded_method=:cutoff,
         dist_cutoff=1.0u"nm",
-        dispersion_correction=false,
     )
 
     dexp = only(inter for inter in sys.pairwise_inters if inter isa DoubleExponential)


### PR DESCRIPTION
Fixes a bug where dispersion correction was still being loaded despite not being defined in XML files using `CustomNonbondedForce`. The bug happened because a mistaken indexing in the `ff_param_array` when the XML was being read and loaded.