### PR TITLE
ANI: fix GPU device selection so NN weights land on the data's device

### DIFF
--- a/ext/MollyLuxExt.jl
+++ b/ext/MollyLuxExt.jl
@@ -1563,7 +1563,10 @@ function Molly.compute_ani_energy_ka(
                                  backend = backend, neighbors = neighbors,
                                  boundary = boundary)   # (n_atoms, aev_len)
     on_gpu = !(aevs isa Array)
-    dev    = on_gpu ? Lux.gpu_device() : Lux.cpu_device()
+    # Derive the device from the actual data array (get_device) rather than Lux's global
+    # gpu_device(), which needs a GPU trigger package (cuDNN/LuxCUDA) loaded and otherwise silently
+    # returns a CPUDevice — leaving the NN weights on the host while the AEVs are on the GPU.
+    dev    = on_gpu ? Lux.get_device(aevs) : Lux.cpu_device()
 
     sp_host     = Array(species)
     idx_to_elem = Dict(v => k for (k, v) in pot.species_map)
@@ -1639,7 +1642,10 @@ end
 function ani_energy_aev_grad_ka(aevs, species, pot, n_species::Int; backend=nothing, need_energy::Bool=true)
     ka_backend = isnothing(backend) ? KernelAbstractions.get_backend(aevs) : backend
     on_gpu = !(aevs isa Array)
-    dev    = on_gpu ? Lux.gpu_device() : Lux.cpu_device()
+    # Derive the device from the actual data array (get_device) rather than Lux's global
+    # gpu_device(), which needs a GPU trigger package (cuDNN/LuxCUDA) loaded and otherwise silently
+    # returns a CPUDevice — leaving the NN weights on the host while the AEVs are on the GPU.
+    dev    = on_gpu ? Lux.get_device(aevs) : Lux.cpu_device()
     n_atoms, aev_len = size(aevs)
     sp_host     = Array(species)
     idx_to_elem = Dict(v => k for (k, v) in pot.species_map)


### PR DESCRIPTION
## Summary

Fixes the ANI-2x `potential_energy`/`forces` failure on CUDA reported in the "GPU path from setup matches CPU" test:

```
ArgumentError: Objects are on devices with different types: CPUDevice and CUDADevice.   # energy
ArgumentError: Illegal conversion of a CUDA.DeviceMemory to a Ptr{Float32}              # forces
```

## Cause

`compute_ani_energy_ka` and `ani_energy_aev_grad_ka` selected the device for the on-device NN weights with `Lux.gpu_device()`. That relies on MLDataDevices' **GPU auto-detection**, which only considers a GPU "functional" when a trigger package (**cuDNN** / **LuxCUDA**) is loaded — not just `CUDA.jl`. The Molly test suite loads `using CUDA` but not cuDNN, so `Lux.gpu_device()` emits *"No functional GPU backend found! Defaulting to CPU."* and returns a `CPUDevice`. The NN weights then stay on the host while the AEVs are `CuArray`s, and the first `weight * aev` matmul throws.

(This is why it can pass in an environment that happens to have cuDNN/LuxCUDA loaded, and fail in the standard test env.)

## Fix

Pick the device from the **actual data array** with `Lux.get_device(aevs)` instead of the global `Lux.gpu_device()`. `get_device` reads the device off the array itself, works with only `CUDA.jl` loaded, and returns a stable-typed device object so the `ani_nn_dev_params` on-device weight cache (keyed on `typeof(dev)`) still works. Two lines, no API change.

## Verification

On an NVIDIA RTX 5080 with **only `using CUDA`** loaded (the failing config):
- Before: `Lux.gpu_device()` → `CPUDevice`, the errors above.
- After: `Lux.get_device(cuarray)` → `CUDADevice`; a small water molecule gives energy CPU vs GPU `|Δ| = 8e-6` and forces max-diff `3e-4` — GPU energy and forces match CPU.
